### PR TITLE
Make Server variable object enum optional, closes #15

### DIFF
--- a/lib/open_api/spec/server/variable.ex
+++ b/lib/open_api/spec/server/variable.ex
@@ -6,7 +6,7 @@ defmodule OpenAPI.Spec.Server.Variable do
   #
 
   @type t :: %__MODULE__{
-          enum: [String.t()],
+          enum: nonempty_list(String.t()) | nil,
           default: String.t(),
           description: String.t() | nil
         }
@@ -24,7 +24,7 @@ defmodule OpenAPI.Spec.Server.Variable do
   @spec decode(map, map) :: {map, t}
   def decode(state, yaml) do
     variable = %__MODULE__{
-      enum: Map.fetch!(yaml, "enum"),
+      enum: Map.get(yaml, "enum"),
       default: Map.fetch!(yaml, "default"),
       description: Map.get(yaml, "description")
     }


### PR DESCRIPTION
According to spec the `enum` property of the Server Variable Object is not required.
Also it should be not empty if defined. Reference: [OpenAPI 3.1.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object)