### PR TITLE
Convert function argument from camel case into underscore case

### DIFF
--- a/lib/open_api/generator/operation.ex
+++ b/lib/open_api/generator/operation.ex
@@ -14,7 +14,7 @@ defmodule OpenAPI.Generator.Operation do
   def process(state, path, params_from_path, method, operation) do
     {state, body} = process_body(state, operation)
     {state, responses} = responses(state, operation)
-    path_params = path_params(state, path, params_from_path, operation)
+    {path_params, updated_path} = path_params(state, path, params_from_path, operation)
     query_params = query_params(state, operation)
     operation = maybe_with_tags(state, operation)
 
@@ -27,12 +27,7 @@ defmodule OpenAPI.Generator.Operation do
           method: method,
           module: gen_module(state, modules),
           name: function,
-          path:
-            path_params
-            |> Enum.reduce(path, fn {name, var, _, _}, path ->
-              path
-              |> String.replace(name, var)
-            end),
+          path: updated_path,
           path_params: path_params,
           query_params: query_params,
           responses: responses,
@@ -134,12 +129,22 @@ defmodule OpenAPI.Generator.Operation do
       |> Enum.map(&parameter(state, &1))
       |> Enum.into(%{})
 
-    String.split(path, ~r/(^|\})[^\{\}]*(\{|$)/, trim: true)
-    |> Enum.map(fn name ->
-      schema = all_params[name].schema
-      type = Typing.schema_to_type(state, schema)
-      {name, Macro.underscore(name), schema, type}
-    end)
+    path_param_names = String.split(path, ~r/(^|\})[^\{\}]*(\{|$)/, trim: true)
+
+    params =
+      Enum.map(path_param_names, fn name ->
+        schema = all_params[name].schema
+        type = Typing.schema_to_type(state, schema)
+        {Macro.underscore(name), schema, type}
+      end)
+
+    path =
+      Enum.reduce(path_param_names, path, fn original_name, path ->
+        underscored_name = Macro.underscore(original_name)
+        String.replace(path, "{#{original_name}}", "{#{underscored_name}}")
+      end)
+
+    {params, path}
   end
 
   defp query_params(state, %Operation{parameters: parameters}) do

--- a/lib/open_api/generator/operation.ex
+++ b/lib/open_api/generator/operation.ex
@@ -27,7 +27,12 @@ defmodule OpenAPI.Generator.Operation do
           method: method,
           module: gen_module(state, modules),
           name: function,
-          path: path,
+          path:
+            path_params
+            |> Enum.reduce(path, fn {name, var, _, _}, path ->
+              path
+              |> String.replace(name, var)
+            end),
           path_params: path_params,
           query_params: query_params,
           responses: responses,
@@ -133,7 +138,7 @@ defmodule OpenAPI.Generator.Operation do
     |> Enum.map(fn name ->
       schema = all_params[name].schema
       type = Typing.schema_to_type(state, schema)
-      {name, schema, type}
+      {name, Macro.underscore(name), schema, type}
     end)
   end
 

--- a/lib/open_api/generator/render.ex
+++ b/lib/open_api/generator/render.ex
@@ -253,8 +253,8 @@ defmodule OpenAPI.Generator.Render do
 
   defp render_operation_function(operation, module_name) do
     path_parameter_arguments =
-      Enum.map(operation.path_params, fn {name, _spec, _type} ->
-        {String.to_atom(name), [], nil}
+      Enum.map(operation.path_params, fn {_name, var, _spec, _type} ->
+        {String.to_atom(var), [], nil}
       end)
 
     body_argument = if operation.body, do: quote(do: body)
@@ -279,7 +279,7 @@ defmodule OpenAPI.Generator.Render do
     name = String.to_atom(operation.name)
 
     path_parameter_arguments =
-      Enum.map(operation.path_params, fn {_, _, type} ->
+      Enum.map(operation.path_params, fn {_, _, _, type} ->
         quote(do: unquote(to_type(type)))
       end)
 
@@ -324,9 +324,9 @@ defmodule OpenAPI.Generator.Render do
     args =
       if length(operation.path_params) > 0 or not is_nil(operation.body) do
         args =
-          Enum.map(operation.path_params, fn {name, _spec, _type} ->
+          Enum.map(operation.path_params, fn {name, var, _spec, _type} ->
             arg_as_atom = String.to_atom(name)
-            {arg_as_atom, {arg_as_atom, [], nil}}
+            {arg_as_atom, {String.to_atom(var), [], nil}}
           end)
 
         body_arg = unless is_nil(operation.body), do: {:body, {:body, [], nil}}

--- a/lib/open_api/generator/render.ex
+++ b/lib/open_api/generator/render.ex
@@ -253,8 +253,8 @@ defmodule OpenAPI.Generator.Render do
 
   defp render_operation_function(operation, module_name) do
     path_parameter_arguments =
-      Enum.map(operation.path_params, fn {_name, var, _spec, _type} ->
-        {String.to_atom(var), [], nil}
+      Enum.map(operation.path_params, fn {name, _spec, _type} ->
+        {String.to_atom(name), [], nil}
       end)
 
     body_argument = if operation.body, do: quote(do: body)
@@ -279,7 +279,7 @@ defmodule OpenAPI.Generator.Render do
     name = String.to_atom(operation.name)
 
     path_parameter_arguments =
-      Enum.map(operation.path_params, fn {_, _, _, type} ->
+      Enum.map(operation.path_params, fn {_, _, type} ->
         quote(do: unquote(to_type(type)))
       end)
 
@@ -324,9 +324,9 @@ defmodule OpenAPI.Generator.Render do
     args =
       if length(operation.path_params) > 0 or not is_nil(operation.body) do
         args =
-          Enum.map(operation.path_params, fn {name, var, _spec, _type} ->
+          Enum.map(operation.path_params, fn {name, _spec, _type} ->
             arg_as_atom = String.to_atom(name)
-            {arg_as_atom, {String.to_atom(var), [], nil}}
+            {arg_as_atom, {arg_as_atom, [], nil}}
           end)
 
         body_arg = unless is_nil(operation.body), do: {:body, {:body, [], nil}}


### PR DESCRIPTION
Grab some demo from [LINE SDK for Elixir](https://github.com/wingyplus/line_bot_sdk_elixir/pull/1):

```diff
diff --git a/lib/line/messaging_api/messaging_api.ex b/lib/line/messaging_api/messaging_api.ex
index d1ad297..d9c8afa 100644
--- a/lib/line/messaging_api/messaging_api.ex
+++ b/lib/line/messaging_api/messaging_api.ex
@@ -141,11 +141,11 @@ defmodule LINE.MessagingAPI.MessagingApi do

   """
   @spec delete_rich_menu(String.t(), keyword) :: :ok | :error
-  def delete_rich_menu(richMenuId, opts \\ []) do
+  def delete_rich_menu(rich_menu_id, opts \\ []) do
     client = opts[:client] || @default_client

     client.request(%{
-      args: [richMenuId: richMenuId],
+      args: [richMenuId: rich_menu_id],
       call: {LINE.MessagingAPI.MessagingApi, :delete_rich_menu},
       url: "/v2/bot/richmenu/#{richMenuId}",
       method: :delete,
```

The pending issue is string interpolation in URL path params that use regular expressions to settle this. I quite doubt how to convert that value (probably it's already midnight in my time zone). 

I would like to open this to discuss and collect the feedback before moving forward. :)