### PR TITLE
Implementation proposal for operation parameters with `:cookie` and `:header`  location and test case for rendered code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**Add** Added OpenAPI.Test.RecorderCase to easily create code from specs in `test/fixture/<test>.{yml|yaml}`
 **Add**: Added headers and cookie parameter location handling. The request options now contain tuples such as `{"X-Header-Value", "some header value"}` and `{"cookie-name", "some cookie value"}`.
 The options used to generate the cookie and headers value are also forwarded in the `opts` keyword argument to `client.request`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**Add**: Added headers and cookie parameter location handling. The request options now contain tuples such as `{"X-Header-Value", "some header value"}` and `{"cookie-name", "some cookie value"}`.
+The options used to generate the cookie and headers value are also forwarded in the `opts` keyword argument to `client.request`
+
 ### 0.1.0-rc.3 (2023-09-29)
 
 **Fix**: Cyclical schema references would result in an infinite loop during the read phase.
-  This has been fixed specifically for schema references; if references that don't point to schemas create a cycle, generation will still fail.
+This has been fixed specifically for schema references; if references that don't point to schemas create a cycle, generation will still fail.
 
 ### 0.1.0-rc.2 (2023-09-27)
 
@@ -20,27 +23,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Fix**: Schema output was non-deterministic due to map ordering and an issue tracking contexts.
 **Fix**: Warn when an enum type is invalid (ex. contains schemas).
-  In this case, the type will be expanded to `:any` but otherwise continue processing.
+In this case, the type will be expanded to `:any` but otherwise continue processing.
 **Fix**: Map types were output as the literal atom `:map` instead of `map` in typespecs.
 **Fix**: Preserve indentation of operation docstrings.
 **Fix**: Always include `args` in client calls, even if the list is empty.
 **Fix**: Ensure the app is started in `mix api.gen`.
-  This resolves an issue in which configured processor or renderer modules may not be available.
+This resolves an issue in which configured processor or renderer modules may not be available.
 
 ## 0.1.0-rc.0 (2023-09-06)
 
 **Breaking**: This is a major release.
-  See the [migration guide](guides/migration.md) for more information.
+See the [migration guide](guides/migration.md) for more information.
 **Add**: Plugin system for overriding the behavior of this library.
-  See the [plugins guide](guides/plugins.md) for more information.
+See the [plugins guide](guides/plugins.md) for more information.
 **Add**: Additional internal types to represent string variations, enums, etc.
 **Fix**: Uniformly normalize names of operations and schemas.
 
 ### 0.0.8 (2023-09-06)
 
 **Fix**: Path parameters are now collected from more locations in the spec.
-  Previously, the generator only noticed path parameters declared in the individual path _items_.
-  This may cause breaking changes in some operation functions, however they were likely unusable before.
+Previously, the generator only noticed path parameters declared in the individual path _items_.
+This may cause breaking changes in some operation functions, however they were likely unusable before.
 **Fix**: Ensure all path parameter keys are properly underscored (thanks [wingyplus](https://github.com/wingyplus)!).
 
 ### 0.0.7 (2023-06-07)
@@ -54,36 +57,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 0.0.6 (2023-05-17)
 
-* **Add**: New `extra_fields` option to allow library authors to create their own private fields on generated structs.
+- **Add**: New `extra_fields` option to allow library authors to create their own private fields on generated structs.
   The location and semantics of this option are likely to be changed in the future.
-* **Fix**: Include `body` argument in `args` passed to the client.
+- **Fix**: Include `body` argument in `args` passed to the client.
   Clients may rely on this information (the values themselves, or the arity) for their operations, especially in testing situations.
 
 ### 0.0.5 (2023-05-16)
 
-* **Fix**: Replace all non-alphanumeric characters when naming tagged operations.
-* **Fix**: Handle nullable union types with no realizable non-null types.
+- **Fix**: Replace all non-alphanumeric characters when naming tagged operations.
+- **Fix**: Handle nullable union types with no realizable non-null types.
   This case occurred in the GitHub spec (see [github/rest-api-description#2534](https://github.com/github/rest-api-description/issues/2534)).
 
 ### 0.0.4 (2023-05-10)
 
-* **Add**: Add `call` information to client calls.
+- **Add**: Add `call` information to client calls.
   This will allow specialized clients, like a test mock, to introspect the original calling function without the use of stack traces.
-* **Fix**: Add missing type `:map` to `OpenAPI.Generator.Typing.t()`.
-* **Fix**: Support `default` entry in responses object (thanks [@aej](https://github.com/aej)!).
-* **Fix**: Strip spaces and repetitive dash/underscore/whitespace characters when naming operations (thanks [@feynmanliang](https://github.com/feynmanliang)!).
+- **Fix**: Add missing type `:map` to `OpenAPI.Generator.Typing.t()`.
+- **Fix**: Support `default` entry in responses object (thanks [@aej](https://github.com/aej)!).
+- **Fix**: Strip spaces and repetitive dash/underscore/whitespace characters when naming operations (thanks [@feynmanliang](https://github.com/feynmanliang)!).
 
 ### 0.0.3 (2023-02-19)
 
-* **Add**: Add `args` keyword list to client calls.
+- **Add**: Add `args` keyword list to client calls.
   This will allow specialized clients, like a test mock, to differentiate between static URL segments and dynamic path parameters.
 
 ### 0.0.2 (2023-02-17)
 
-* **Add**: Support OpenAPI 3.1 `"null"` type
-* **Add**: Support `type` field given as an array of primitive types
-* **Fix**: Infer `map` type in more cases when `type` field is unspecified
+- **Add**: Support OpenAPI 3.1 `"null"` type
+- **Add**: Support `type` field given as an array of primitive types
+- **Fix**: Infer `map` type in more cases when `type` field is unspecified
 
 ### 0.0.1 (2023-01-05)
 
-* **Initial Release**
+- **Initial Release**

--- a/lib/open_api/processor.ex
+++ b/lib/open_api/processor.ex
@@ -274,6 +274,8 @@ defmodule OpenAPI.Processor do
 
     path_params = Enum.filter(all_params, &(&1.location == :path))
     query_params = Enum.filter(all_params, &(&1.location == :query))
+    header_parameters = Enum.filter(all_params, &(&1.location == :header))
+    cookie_parameters = Enum.filter(all_params, &(&1.location == :cookie))
 
     docstring = implementation.operation_docstring(state, operation_spec, query_params)
     module_names = implementation.operation_module_names(state, operation_spec)
@@ -300,6 +302,8 @@ defmodule OpenAPI.Processor do
           request_path: request_path,
           request_path_parameters: path_params,
           request_query_parameters: query_params,
+          request_header_parameters: header_parameters,
+          request_cookie_parameters: cookie_parameters,
           responses: response_body
         }
 

--- a/lib/open_api/processor/operation.ex
+++ b/lib/open_api/processor/operation.ex
@@ -40,6 +40,8 @@ defmodule OpenAPI.Processor.Operation do
           request_path: String.t(),
           request_path_parameters: [Param.t()],
           request_query_parameters: [Param.t()],
+          request_header_parameters: [Param.t()],
+          request_cookie_parameters: [Param.t()],
           responses: response_body
         }
 
@@ -52,6 +54,8 @@ defmodule OpenAPI.Processor.Operation do
     :request_path,
     :request_path_parameters,
     :request_query_parameters,
+    :request_header_parameters,
+    :request_cookie_parameters,
     :responses
   ]
 

--- a/lib/open_api/renderer/util.ex
+++ b/lib/open_api/renderer/util.ex
@@ -14,6 +14,7 @@ defmodule OpenAPI.Renderer.Util do
   alias OpenAPI.Processor.Type
   alias OpenAPI.Renderer.File
   alias OpenAPI.Renderer.State
+  alias OpenAPI.Processor.Operation.Param
 
   @doc """
   Flatten and remove `nil` elements from a list of AST nodes
@@ -189,6 +190,49 @@ defmodule OpenAPI.Renderer.Util do
   end
 
   def to_readable_type(_state, type), do: type
+
+  @doc """
+    Transforms "X-Parameter-name" parameters to :parameter_name atom.
+
+    The transformation
+
+    * removes "X-" from the parameter name
+    * applies &String.downcase/1
+    * replaces "-" with "_"
+
+    This function uses &String.to_atom/1, so it is unsafe for untrusted input.
+  """
+  @spec header_name_to_atom(Param.t()) :: atom()
+  def header_name_to_atom(%Param{name: "x-" <> name} = param),
+    do: header_name_to_atom(%Param{param | name: name})
+
+  def header_name_to_atom(%Param{name: "X-" <> name} = param),
+    do: header_name_to_atom(%Param{param | name: name})
+
+  def header_name_to_atom(%Param{name: name}),
+    do:
+      name
+      |> String.replace("-", "_")
+      |> String.downcase()
+      |> String.to_atom()
+
+  @doc """
+  Transforms string typed cookie parameters into atoms
+
+  The transformation
+
+  * applies &String.downcase/1
+  * replaces "-" with "_"
+
+  This function uses &String.to_atom/1, so it is unsafe for untrusted input.
+  """
+  @spec cookie_name_to_atom(Param.t()) :: atom()
+  def cookie_name_to_atom(%Param{name: name}),
+    do:
+      name
+      |> String.downcase()
+      |> String.replace("-", "_")
+      |> String.to_atom()
 
   @doc """
   Render an internal type as a typespec

--- a/test/fixture/cookie_header_params.yaml
+++ b/test/fixture/cookie_header_params.yaml
@@ -1,0 +1,34 @@
+openapi: "3.1.0"
+info:
+  title: Parameters in cookie and headers
+  version: 1
+paths:
+  "/req-headers":
+    get:
+      description: "Example endpoint"
+      operationId: example
+      summary: "Example endpoint"
+      parameters:
+        - description: |-
+            Header parameter example.
+            The corresponding option should be :header_param
+          example: header param value
+          in: header
+          name: X-Header-Param
+          schema:
+            type: string
+        - description: |-
+           This Parameter is passed as a cookie
+           It should be set using the name :cookie_param
+          example: cookie-value
+          in: cookie
+          name: cookie-param
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "Success"
+          content:
+            "application/json":
+              schema:
+                type: string

--- a/test/open_api/generator/operation_test.exs
+++ b/test/open_api/generator/operation_test.exs
@@ -1,7 +1,7 @@
 defmodule OpenAPI.Generator.OperationTest do
   use ExUnit.Case, async: true
 
-  alias OpenAPI.Generator.Operation
+  alias OpenAPI.Spec.Path.Operation
   alias OpenAPI.Spec.Path
 
   describe "names/1" do

--- a/test/open_api/renderer_test.exs
+++ b/test/open_api/renderer_test.exs
@@ -1,0 +1,26 @@
+defmodule OpenAPI.Test.RendererTest do
+  use OpenAPI.Test.RecorderCase
+
+  test "test query parameters" do
+    run_fixture(:cookie_header_params)
+    %{file: %{contents: contents}, state: state} = output_file("operations.ex")
+
+    assert_contains_code(
+      contents,
+      """
+      header_parameters =
+        Keyword.take(opts, [:header_param])
+        |> Enum.map(fn {:header_param, value} -> {"X-Header-Param", value} end)
+      """
+    )
+
+    assert contains_code?(
+             contents,
+             """
+             cookie_parameters =
+               Keyword.take(opts, [:cookie_param])
+               |> Enum.map(fn {:cookie_param, value} -> {"cookie-param", value} end)
+             """
+           )
+  end
+end

--- a/test/support/code_helpers.ex
+++ b/test/support/code_helpers.ex
@@ -1,0 +1,81 @@
+defmodule OpenAPI.Test.CodeHelpers do
+  @doc """
+  compares code with any viable indentation.
+  the identation is deduces from the first occurence of the first word in the generated output
+
+  if the generated parameter is a list it is joined before comparing using `gen_list|> Enum.join()`
+  """
+
+  def contains_code?(generated, cmp) when is_bitstring(generated) do
+    with cmp <-
+           (if String.last(cmp) == "\n" do
+              String.slice(cmp, 0, String.length(cmp) - 1)
+            else
+              cmp
+            end),
+         first_word <-
+           Regex.replace(~r/^(\s*[^[:space:]]+).*/, cmp, "\\1")
+           |> String.split("\n")
+           |> Enum.find(fn
+             "" -> false
+             _ -> true
+           end),
+         possible_indents <-
+           generated
+           |> String.split("\n")
+           |> Enum.reduce([], fn line, acc ->
+             case String.split(line, first_word) do
+               [_just_one] ->
+                 acc
+
+               [spaces | _] ->
+                 if spaces == String.duplicate(" ", String.length(spaces)) do
+                   [String.length(spaces) | acc]
+                 else
+                   acc
+                 end
+
+               _ ->
+                 acc
+             end
+           end) do
+      possible_indents
+      |> Enum.find(fn indent ->
+        prefix = String.duplicate(" ", indent)
+
+        cmp =
+          cmp
+          |> String.split("\n")
+          |> Enum.map(fn
+            "" -> ""
+            other -> prefix <> other
+          end)
+          |> Enum.join("\n")
+
+        String.contains?(generated, cmp)
+      end)
+    end
+  end
+
+  def contains_code?(gen_list, cmp) when is_list(gen_list),
+    do: gen_list |> Enum.join() |> contains_code?(cmp)
+
+  @doc """
+    assert macro for   contains_code?
+    the msg argument, if supplied is passed on to assert
+  """
+  @spec assert_contains_code(any(), any(), any()) ::
+          {:assert, [{:column, 9} | {:keep, {any(), any()}}, ...], [...]}
+  defmacro assert_contains_code(source, cmp, msg \\ nil) do
+    if msg do
+      quote location: :keep do
+        assert OpenAPI.Test.CodeHelpers.contains_code?(unquote(source), unquote(cmp)),
+               unquote(msg)
+      end
+    else
+      quote location: :keep do
+        assert OpenAPI.Test.CodeHelpers.contains_code?(unquote(source), unquote(cmp))
+      end
+    end
+  end
+end

--- a/test/support/recorder_case.ex
+++ b/test/support/recorder_case.ex
@@ -1,0 +1,85 @@
+defmodule OpenAPI.Test.RecorderCase do
+  use ExUnit.CaseTemplate
+
+  @moduledoc """
+  Test Case for using specs in fixture and recording the generation process
+
+  """
+  using do
+    module = __MODULE__
+
+    quote do
+      alias OpenAPI.Test.RecorderRenderer
+      import OpenAPI.Test.CodeHelpers
+      require OpenAPI.Test.CodeHelpers
+
+      defdelegate fixture_file_path(name_or_atom), to: unquote(module)
+      defdelegate recorder_profile(), to: unquote(module)
+      defdelegate run_fixture(name_or_atom), to: unquote(module)
+      defdelegate output_file(file), to: unquote(module)
+    end
+  end
+
+  @doc """
+  Retrieves the contents of the output file, and the state from the renderer call as a string.
+  returns nil if file does not exist
+  """
+  @spec output_file(bitstring()) :: any()
+  def output_file(file) when is_bitstring(file),
+    do: OpenAPI.Test.RecorderRenderer.get_file(file)
+
+  @doc """
+  runs the fixture with test recording
+  """
+  @spec run_fixture(atom() | binary()) :: :ok
+  def run_fixture(name_or_atom) do
+    with spec_path <-
+           fixture_file_path!(name_or_atom),
+         profile <-
+           recorder_profile(),
+         initial_test_profile <-
+           Application.get_env(:oapi_generator, :test_profile) do
+      Application.put_env(:oapi_generator, :test_profile, profile)
+      OpenAPI.run("test_profile", [spec_path])
+      Application.put_env(:oapi_generator, :test_profile, initial_test_profile)
+    end
+  end
+
+  def fixture_file_path!(atom_or_name) do
+    case fixture_file_path(atom_or_name) do
+      nil -> throw("No Fixture file found for #{inspect(atom_or_name)}")
+      path -> path
+    end
+  end
+
+  @doc """
+  Finds a fixture file from it's name (string or atom) without path or extension:
+
+  `fixture_file_path(:cookie_header_params)` -> 'test/fixture/cookie_header_params.yaml'
+  """
+  @spec fixture_file_path(binary() | atom()) :: binary() | nil
+  def fixture_file_path(atom_name) when is_atom(atom_name),
+    do: atom_name |> to_string() |> fixture_file_path()
+
+  def fixture_file_path(fixture_file_param) when is_bitstring(fixture_file_param) do
+    fixture_file =
+      case Path.split(fixture_file_param) do
+        [file_name] -> Path.join(["test", "fixture", file_name])
+        _ -> fixture_file_param
+      end
+
+    [fixture_file, fixture_file <> ".yml", fixture_file <> ".yaml"]
+    |> Enum.find(fn path ->
+      case Path.wildcard(path) do
+        [file] -> file
+        _ -> nil
+      end
+    end)
+  end
+
+  @spec recorder_profile() :: [{:renderer, OpenAPI.Test.RecorderRenderer}, ...]
+  def recorder_profile(),
+    do: [
+      renderer: OpenAPI.Test.RecorderRenderer
+    ]
+end

--- a/test/support/recorder_renderer.ex
+++ b/test/support/recorder_renderer.ex
@@ -1,0 +1,68 @@
+defmodule OpenAPI.Test.RecorderRenderer do
+  @moduledoc """
+  Renderer recording the output and state into an Agent instead of writing to files
+
+  These callbacks are recorded:
+
+  * &OpenAPI.Renderer.write/2
+  * TODO: Expand with other renderer overrides
+
+  For testing use OpenAPI.Test.RecorderCase in test files
+  """
+
+  use OpenAPI.Renderer
+  use Agent
+
+  alias OpenAPI.Renderer.File
+
+  def start_link(),
+    do: Agent.start_link(fn -> %{} end, name: __MODULE__)
+
+  @impl true
+  def write(gen_state, %File{} = file) do
+    runner_process = self()
+    # returns :ok, as expected for write too
+    Agent.update(__MODULE__, fn state ->
+      case Map.get(state, runner_process) do
+        nil ->
+          Map.put(state, runner_process, [%{file: file, state: gen_state}])
+
+        l when is_list(l) ->
+          state |> Map.put(runner_process, l ++ [%{file: file, state: gen_state}])
+      end
+    end)
+  end
+
+  @doc """
+    gets a file from the agent. the file must have been previously recorded
+  """
+  @spec get_file(bitstring() | Regex.t()) :: any()
+  def get_file(%Regex{} = rex),
+    do: do_get_file(rex)
+
+  def get_file(str) when is_bitstring(str),
+    do: do_get_file(str)
+
+  defp do_get_file(match_location) do
+    runner_process = self()
+    matches? = location_matcher(match_location)
+
+    Agent.get(__MODULE__, fn
+      %{^runner_process => records} ->
+        records
+        |> Enum.find(matches?)
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp location_matcher(%Regex{} = rex),
+    do: fn {location, _, _} -> Regex.match?(rex, location) end
+
+  defp location_matcher(cmp),
+    do: fn
+      %{file: %{location: ^cmp}} -> true
+      _ -> false
+    end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+OpenAPI.Test.RecorderRenderer.start_link()
 ExUnit.start()


### PR DESCRIPTION
I formulated this directly as a PR, because i could not find an easy way to enhance `OpenAPI.Processor.Operation` with the additional stuct  fields needed  (`Operation.request_header_parameters` and `Operation.request_cookie_parameters`)  for handling `:cookie` and `:header` parameters.

I think a way to add additional info, or a way to access the spec right down to the renderer would be helpful, if this was to be implemented as a plugin. I really appreciate the clean separation of concern in `open-api-generator`, though. This does however hamper creating plugins which need spec info in custom renderer implementations.


##  request parameters with `:cookie` and `:header` location
To handle the [ory kratos spec](https://github.com/ory/sdk/blob/master/spec/kratos/v1.0.0.json), at least the `:header` location needed an implementation, but i decided to also implement `:cookie` parameters.

The generated code in `operation.ex` for a spec containing `:header` and `:cookie` parameters, generated from [the test spec in my fork](https://github.com/paulbalomiri/open-api-generator/blob/main/test/fixture/cookie_header_params.yaml) looks like this:

```elixir
defmodule Operations do
  @moduledoc """
  Provides API endpoint related to operations
  """

  @default_client Client

  @doc """
  Example endpoint

  Example endpoint
  """
  @spec example(keyword) :: {:ok, String.t()} | :error
  def example(opts \\ []) do
    client = opts[:client] || @default_client

    header_parameters =
      Keyword.take(opts, [:header_param])
      |> Enum.map(fn {:header_param, value} -> {"X-Header-Param", value} end)

    cookie_parameters =
      Keyword.take(opts, [:cookie_param])
      |> Enum.map(fn {:cookie_param, value} -> {"cookie-param", value} end)

    client.request(%{
      args: [],
      call: {Operations, :example},
      url: "/req-headers",
      method: :get,
      headers: header_parameters,
      cookie: cookie_parameters,
      response: [{200, {:string, :generic}}],
      opts: opts
    })
  end
end
```

- **parameter** names are expected as atoms, and are then mapped to their respective spec keys when sending to client request.
- The mapper function is generated with  additional clauses  for each additional header or cookie parameter passed via `option`
The `header_parameters=`  line with 4 params looks like so:
 
```elixir
    header_parameters =
      Keyword.take(opts, [:header_param, :header_param2, :authorization, :no_x_header_param])
      |> Enum.map(fn
        {:header_param, value} -> {"X-Header-Param", value}
        {:header_param2, value} -> {"X-Header-Param2", value}
        {:authorization, value} -> {"authorization", value}
        {:no_x_header_param, value} -> {"no-x-Header-Param", value}
      end)

````
I will not include here also the cookie mapping for multiple parameters as it's similar, but the `X-` (or `x-` prefix is not stripped.

## Test suite
I also created a test suite, which can be used to test output files generated using specs in `test/fixture/*.{yml|yaml}`

The functionality of this PR is tested ( in [`/test/open_api/renderer_test.exs`](https://github.com/paulbalomiri/open-api-generator/blob/main/test/open_api/renderer_test.exs) using `OpenAPI.Test.RecorderCase`


**EDIT** corrected [some links](https://github.com/aj-foster/open-api-generator/pull/28#issuecomment-1772225797)

