### PR TITLE
Support discriminator without mapping

### DIFF
--- a/lib/open_api/spec/schema/discriminator.ex
+++ b/lib/open_api/spec/schema/discriminator.ex
@@ -24,7 +24,7 @@ defmodule OpenAPI.Spec.Schema.Discriminator do
   def decode(state, yaml) do
     discriminator = %__MODULE__{
       property_name: Map.fetch!(yaml, "propertyName"),
-      mapping: Map.fetch!(yaml, "mapping")
+      mapping: Map.get(yaml, "mapping", %{})
     }
 
     {state, discriminator}


### PR DESCRIPTION
Hi AJ! We met briefly after your talk at ElixirConf. ☺️ Thanks so much for your work on this.

I ran the generator on the Customer.io OpenAPI spec (available from the Download button [here](https://customer.io/docs/api/app/)). It _mostly_ worked as-is, but they have one part of the schema that looks like this:

```json
"discriminator": {
  "propertyName": "object_type"
}
```

Based on my reading of the OpenAPI 3.0.0 spec, this is legal, although a little weird. The change in this patch fixes the crash that resulted from that bit.