### PR TITLE
Avoid unwrapping array types in typespecs

### DIFF
--- a/lib/open_api/renderer/operation.ex
+++ b/lib/open_api/renderer/operation.ex
@@ -344,7 +344,7 @@ defmodule OpenAPI.Renderer.Operation do
 
     opts = quote(do: keyword)
 
-    arguments = Util.clean_list([path_parameters, request_body, opts])
+    arguments = path_parameters ++ Enum.reject([request_body, opts], &is_nil/1)
     return_type = render_return_type(state, responses)
 
     quote do


### PR DESCRIPTION
This PR fixes an issue that affects the typespecs of operation functions with an array type for the `body` argument. This portion of the typespec was inappropriately unwrapped using `List.flatten/1`, creating an incorrect spec.

Relates to #33.