### PR TITLE
Fix elixir 1.16.x warning for Enum.slice negative index

### DIFF
--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -116,7 +116,7 @@ defmodule OpenAPI.Processor.Naming do
     modules =
       if id do
         String.split(id, "/", trim: true)
-        |> Enum.slice(0..-2)
+        |> Enum.slice(0..-2//1)
       else
         []
       end


### PR DESCRIPTION
This fixes #41 