### PR TITLE
Fix missing import statement in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Hex.pm](https://img.shields.io/hexpm/v/oapi_generator)](https://hex.pm/packages/oapi_generator)
 [![Documentation](https://img.shields.io/badge/hex-docs-blue)](https://hexdocs.pm/oapi_generator)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 _A highly-configurable code generator that combines ergonomics with maintainability._
 
@@ -50,9 +50,13 @@ The real power of this library is in the available configuration.
 Although the options are conceptually simple, they add up to a better user experience.
 
 This project uses configuration profiles to allow multiple configurations with the same package.
-To get started, create a profile called `default` in your configuration:
+To get started, create a profile called `default` in your configuration file:
 
 ```elixir
+# config/config.exs
+
+import Config
+
 config :oapi_generator, default: [
   output: [
     base_module: Example,

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -16,7 +16,7 @@ For example:
 ```elixir
 # config/config.exs
 
-Import Config
+import Config
 
 config :oapi_generator,
   my_profile: [

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -16,6 +16,8 @@ For example:
 ```elixir
 # config/config.exs
 
+Import Config
+
 config :oapi_generator,
   my_profile: [
     output: [
@@ -287,7 +289,7 @@ Remember that all configuration values must be contained within a profile.
   This is an optional way to colocate generated operation modules in a single directory away from other parts of the client library.
   Defaults to the same location as `output.location`.
   See `OpenAPI.Renderer.Module.filename/2` for more information.
-  
+
 * `output.operation_use`: Module to include as a `use` statement at the top of every module containing operations.
   Defaults to no used module.
   See `OpenAPI.Renderer.Module.render_using/2` for more information.


### PR DESCRIPTION
Make it easier to copy and paste the examples given in the docs.