### PR TITLE
Check code format in GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,32 @@ on: [pull_request]
 jobs:
   test:
     name: "Test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    # See https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
+    strategy:
+      matrix:
+        include:
+          - pair:
+              otp: "23.3.4.20"
+              elixir: "1.14.5"
+          - pair:
+              otp: "26.2.5"
+              elixir: "1.16.2"
+            lint: lint
     env:
       MIX_ENV: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "25.2"
-          elixir-version: "1.14.2"
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
 
       - name: Fetch Hex Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: hex-cache
         with:
           path: |
@@ -28,6 +39,10 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
+
+      - name: Check Code Format
+        run: mix format --check-formatted
+        if: ${{matrix.lint}}
 
       - name: Run Tests
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.16.2-otp-26
-erlang 26.2.2
+erlang 26.2.5

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule OpenAPI.MixProject do
     [
       app: :oapi_generator,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       name: "OpenAPI Generator",

--- a/test/open_api/processor/ignore_test.exs
+++ b/test/open_api/processor/ignore_test.exs
@@ -52,7 +52,9 @@ defmodule OpenAPI.Processor.IgnoreTest do
       base_file_path = ["components", "schemas", "ignored_schema"]
       schema = %OpenAPI.Spec.Schema{schema | "$oag_base_file_path": base_file_path}
 
-      Application.put_env(:oapi_generator, @profile, ignore: ["components/schemas/ignored_schema"])
+      Application.put_env(:oapi_generator, @profile,
+        ignore: ["components/schemas/ignored_schema"]
+      )
 
       assert Ignore.ignore_schema?(state, schema)
     end
@@ -68,7 +70,9 @@ defmodule OpenAPI.Processor.IgnoreTest do
       ref_path = ["components", "schemas", "ignored_schema"]
       schema = %OpenAPI.Spec.Schema{schema | "$oag_last_ref_path": ref_path}
 
-      Application.put_env(:oapi_generator, @profile, ignore: ["components/schemas/ignored_schema"])
+      Application.put_env(:oapi_generator, @profile,
+        ignore: ["components/schemas/ignored_schema"]
+      )
 
       assert Ignore.ignore_schema?(state, schema)
     end


### PR DESCRIPTION
We also tally the minimum supported Erlang/OTP and Elixir versions in the deps and GitHub Actions as well as bump GitHub Actions deps.