### PR TITLE
Mark behaviour callback implementations with @impl attribute

### DIFF
--- a/lib/open_api/processor.ex
+++ b/lib/open_api/processor.ex
@@ -55,15 +55,34 @@ defmodule OpenAPI.Processor do
     quote do
       @behaviour OpenAPI.Processor
 
+      @impl OpenAPI.Processor
       defdelegate ignore_operation?(state, operation), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate ignore_schema?(state, schema), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate operation_docstring(state, operation_spec, params), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate operation_function_name(state, operation_spec), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate operation_module_names(state, operation_spec), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate operation_request_body(state, operation_spec), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate operation_request_method(state, operation_spec), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate operation_response_body(state, operation_spec), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate schema_format(state, schema), to: OpenAPI.Processor
+
+      @impl OpenAPI.Processor
       defdelegate schema_module_and_type(state, schema), to: OpenAPI.Processor
 
       defoverridable ignore_operation?: 2,

--- a/lib/open_api/renderer.ex
+++ b/lib/open_api/renderer.ex
@@ -30,21 +30,52 @@ defmodule OpenAPI.Renderer do
     quote do
       @behaviour OpenAPI.Renderer
 
+      @impl OpenAPI.Renderer
       defdelegate format(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate location(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_default_client(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_moduledoc(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_operations(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_operation(state, operation), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_operation_doc(state, operation), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_operation_function(state, operation), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_operation_spec(state, operation), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_schema(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_schema_field_function(state, schemas), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_schema_struct(state, schemas), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_schema_types(state, schemas), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_using(state, file), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate write(state, file), to: OpenAPI.Renderer
 
       defoverridable format: 2,


### PR DESCRIPTION
When trying to implement my own `OpenAPI.Processor` or `OpenAPI.Renderer` AND adding `@impl` attribute  to my own callback implementations, I'm getting the following warning (one of):
```
    warning: module attribute @impl was not set for function schema_format/2 callback (specified in OpenAPI.Processor). This either means you forgot to add the "@impl true" annotation before the definition or that you are accidentally overriding this callback
    │
  2 │   use OpenAPI.Processor
    │   ~~~~~~~~~~~~~~~~~~~~~
    │
    └─ {REDACTED}/generator/processor.ex:2: {REDACTED}.Generator.Processor (module)
```
Adding the `@impl` attributes to the default implementations gets rid of the warnings.

P.S. Sorry for the commit mess - was trying to build on top of my nested schema references branch 