### PR TITLE
Support custom primitive type formats

### DIFF
--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -109,6 +109,7 @@ Below is a list of all available callbacks in order of their use, along with the
     * `c:OpenAPI.Renderer.render_default_client/2`: `OpenAPI.Renderer.Module.render_default_client/2`
     * `c:OpenAPI.Renderer.render_schema/2`: `OpenAPI.Renderer.Schema.render/2`
       * `c:OpenAPI.Renderer.render_schema_types/2`: `OpenAPI.Renderer.Schema.render_types/2`
+        * `c:OpenAPI.Renderer.render_type/2`: `OpenAPI.Renderer.Util.to_type/2`
       * `c:OpenAPI.Renderer.render_schema_struct/2`: `OpenAPI.Renderer.Schema.render_struct/2`
       * `c:OpenAPI.Renderer.render_schema_field_function/2`: `OpenAPI.Renderer.Schema.render_field_function/2`
     * `c:OpenAPI.Renderer.render_operations/2`: `OpenAPI.Renderer.Operation.render_all/2`

--- a/lib/open_api/processor/type.ex
+++ b/lib/open_api/processor/type.ex
@@ -37,6 +37,7 @@ defmodule OpenAPI.Processor.Type do
           | :uri_reference
           | :uri_template
           | :uuid
+          | String.t()
 
   @typedoc """
   Basic type
@@ -185,6 +186,7 @@ defmodule OpenAPI.Processor.Type do
   defp string_type(%Schema{format: "uri-reference"}), do: {:string, :uri_reference}
   defp string_type(%Schema{format: "uri-template"}), do: {:string, :uri_template}
   defp string_type(%Schema{format: "uuid"}), do: {:string, :uuid}
+  defp string_type(%Schema{format: format}) when is_binary(format), do: {:string, format}
   defp string_type(_schema), do: {:string, :generic}
 
   @spec create_intersection(State.t(), Schema.t(), [Schema.t()]) :: {State.t(), t}

--- a/lib/open_api/processor/type.ex
+++ b/lib/open_api/processor/type.ex
@@ -8,6 +8,10 @@ defmodule OpenAPI.Processor.Type do
   @typedoc "Literal values, as found in `const` and `enum` definitions"
   @type literal :: binary | boolean | number | nil
 
+  @type boolean_format :: String.t()
+  @type integer_format :: String.t()
+  @type number_format :: String.t()
+
   @typedoc """
   Special cases of the string type
 
@@ -48,8 +52,11 @@ defmodule OpenAPI.Processor.Type do
   """
   @type primitive ::
           :boolean
+          | {:boolean, boolean_format}
           | :integer
+          | {:integer, integer_format}
           | :number
+          | {:number, number_format}
           | {:string, string_format}
           | :null
 
@@ -112,9 +119,9 @@ defmodule OpenAPI.Processor.Type do
     end
   end
 
-  def from_schema(state, %Schema{type: "boolean"}), do: {state, :boolean}
-  def from_schema(state, %Schema{type: "integer"}), do: {state, :integer}
-  def from_schema(state, %Schema{type: "number"}), do: {state, :number}
+  def from_schema(state, %Schema{type: "boolean"} = schema), do: {state, boolean_type(schema)}
+  def from_schema(state, %Schema{type: "integer"} = schema), do: {state, integer_type(schema)}
+  def from_schema(state, %Schema{type: "number"} = schema), do: {state, number_type(schema)}
   def from_schema(state, %Schema{type: "null"}), do: {state, :null}
   def from_schema(state, %Schema{type: "string"} = schema), do: {state, string_type(schema)}
 
@@ -161,6 +168,18 @@ defmodule OpenAPI.Processor.Type do
     Logger.warning("Unknown type: #{inspect(schema)}")
     {state, :unknown}
   end
+
+  @spec boolean_type(Schema.t()) :: {:boolean, boolean_format}
+  defp boolean_type(%Schema{format: format}) when is_binary(format), do: {:boolean, format}
+  defp boolean_type(_schema), do: :boolean
+
+  @spec integer_type(Schema.t()) :: {:integer, integer_format}
+  defp integer_type(%Schema{format: format}) when is_binary(format), do: {:integer, format}
+  defp integer_type(_schema), do: :integer
+
+  @spec number_type(Schema.t()) :: {:number, number_format}
+  defp number_type(%Schema{format: format}) when is_binary(format), do: {:number, format}
+  defp number_type(_schema), do: :number
 
   @spec string_type(Schema.t()) :: {:string, string_format}
   defp string_type(%Schema{format: "date"}), do: {:string, :date}

--- a/lib/open_api/renderer.ex
+++ b/lib/open_api/renderer.ex
@@ -8,6 +8,7 @@ defmodule OpenAPI.Renderer do
   """
   alias OpenAPI.Processor.Operation
   alias OpenAPI.Processor.Schema
+  alias OpenAPI.Processor.Type
   alias OpenAPI.Renderer.File
   alias OpenAPI.Renderer.State
 
@@ -73,6 +74,9 @@ defmodule OpenAPI.Renderer do
       defdelegate render_schema_types(state, schemas), to: OpenAPI.Renderer
 
       @impl OpenAPI.Renderer
+      defdelegate render_type(state, schemas), to: OpenAPI.Renderer
+
+      @impl OpenAPI.Renderer
       defdelegate render_using(state, file), to: OpenAPI.Renderer
 
       @impl OpenAPI.Renderer
@@ -92,6 +96,7 @@ defmodule OpenAPI.Renderer do
                      render_schema_field_function: 2,
                      render_schema_struct: 2,
                      render_schema_types: 2,
+                     render_type: 2,
                      render_using: 2,
                      write: 2
     end
@@ -115,6 +120,7 @@ defmodule OpenAPI.Renderer do
                       render_schema_field_function: 2,
                       render_schema_struct: 2,
                       render_schema_types: 2,
+                      render_type: 2,
                       render_using: 2,
                       write: 2
 
@@ -259,6 +265,13 @@ defmodule OpenAPI.Renderer do
   @callback render_schema_types(state :: State.t(), schemas :: [Schema.t()]) :: Macro.t()
 
   @doc """
+  Render the typespec for type
+
+  See `OpenAPI.Renderer.Util.to_type/2` for the default implementation.
+  """
+  @callback render_type(state :: State.t(), Type.t() | {module, atom}) :: Macro.t()
+
+  @doc """
   Render one or more `use` statements to include in the file
 
   Another route for customization of the outputted code is via meta-programming. This callback
@@ -336,6 +349,9 @@ defmodule OpenAPI.Renderer do
 
   @doc false
   defdelegate render_schema_types(state, schemas), to: OpenAPI.Renderer.Schema, as: :render_types
+
+  @doc false
+  defdelegate render_type(state, type), to: OpenAPI.Renderer.Util, as: :to_type
 
   @doc false
   defdelegate render_using(state, file), to: OpenAPI.Renderer.Module

--- a/lib/open_api/renderer/operation.ex
+++ b/lib/open_api/renderer/operation.ex
@@ -383,7 +383,7 @@ defmodule OpenAPI.Renderer.Operation do
     end
   end
 
-  defp render_return_type([], _type_overrides), do: quote(do: :ok)
+  defp render_return_type(_state, []), do: quote(do: :ok)
 
   defp render_return_type(state, responses) do
     %State{implementation: implementation} = state

--- a/lib/open_api/renderer/operation.ex
+++ b/lib/open_api/renderer/operation.ex
@@ -353,6 +353,8 @@ defmodule OpenAPI.Renderer.Operation do
   """
   @spec render_spec(State.t(), Operation.t()) :: Macro.t()
   def render_spec(state, operation) do
+    %State{implementation: implementation} = state
+
     %Operation{
       function_name: name,
       request_body: request_body,
@@ -362,13 +364,13 @@ defmodule OpenAPI.Renderer.Operation do
 
     path_parameters =
       for %Param{value_type: type} <- path_params do
-        quote(do: unquote(Util.to_type(state, type)))
+        quote(do: unquote(implementation.render_type(state, type)))
       end
 
     request_body =
       if length(request_body) > 0 do
         body_type = {:union, Enum.map(request_body, fn {_content_type, type} -> type end)}
-        quote(do: unquote(Util.to_type(state, body_type)))
+        quote(do: unquote(implementation.render_type(state, body_type)))
       end
 
     opts = quote(do: keyword)
@@ -384,6 +386,8 @@ defmodule OpenAPI.Renderer.Operation do
   defp render_return_type([], _type_overrides), do: quote(do: :ok)
 
   defp render_return_type(state, responses) do
+    %State{implementation: implementation} = state
+
     {success, error} =
       responses
       |> Enum.reject(fn {_status, schemas} -> map_size(schemas) == 0 end)
@@ -396,7 +400,7 @@ defmodule OpenAPI.Renderer.Operation do
           success
           |> Enum.map(fn {_state, schemas} -> Map.values(schemas) end)
           |> List.flatten()
-          |> then(&Util.to_type(state, {:union, &1}))
+          |> then(&implementation.render_type(state, {:union, &1}))
 
         quote(do: {:ok, unquote(type)})
       else
@@ -405,14 +409,14 @@ defmodule OpenAPI.Renderer.Operation do
 
     error =
       if error_type = config(state)[:types][:error] do
-        quote(do: {:error, unquote(Util.to_type(state, error_type))})
+        quote(do: {:error, unquote(implementation.render_type(state, error_type))})
       else
         if length(error) > 0 do
           type =
             error
             |> Enum.map(fn {_state, schemas} -> Map.values(schemas) end)
             |> List.flatten()
-            |> then(&Util.to_type(state, {:union, &1}))
+            |> then(&implementation.render_type(state, {:union, &1}))
 
           quote(do: {:error, unquote(type)})
         else

--- a/lib/open_api/renderer/schema.ex
+++ b/lib/open_api/renderer/schema.ex
@@ -119,6 +119,9 @@ defmodule OpenAPI.Renderer.Schema do
   This implementation uses the `output.extra_fields` configuration to add additional fields to
   the struct for private use by the client library. See **Extra Fields** in this module's
   documentation.
+
+  This function calls the `c:OpenAPI.Renderer.render_type/2` callback for every field's type
+
   """
   @spec render_types(State.t(), [Schema.t()]) :: Macro.t()
   def render_types(state, schemas) do
@@ -144,14 +147,16 @@ defmodule OpenAPI.Renderer.Schema do
 
   @spec render_type_fields(State.t(), [Field.t()]) :: Macro.t()
   defp render_type_fields(state, fields) do
+    %State{implementation: implementation} = state
+
     for field <- Enum.sort_by(fields ++ extra_fields(state), & &1.name) do
       %Field{name: name, nullable: nullable?, required: required?, type: type} = field
 
       rendered_type =
         if nullable? or not required? do
-          Util.to_type(state, {:union, [type, :null]})
+          implementation.render_type(state, {:union, [type, :null]})
         else
-          Util.to_type(state, type)
+          implementation.render_type(state, type)
         end
 
       quote do

--- a/lib/open_api/renderer/util.ex
+++ b/lib/open_api/renderer/util.ex
@@ -6,6 +6,7 @@ defmodule OpenAPI.Renderer.Util do
 
     * `c:OpenAPI.Renderer.format/2`
     * `c:OpenAPI.Renderer.write/2`
+    * `c:OpenAPI.Renderer.render_type/2`
 
   It also contains several helpers for working with ASTs, including the addition of formatting
   metadata necessary to create consistent code.
@@ -189,6 +190,8 @@ defmodule OpenAPI.Renderer.Util do
   @doc """
   Render an internal type as a typespec
 
+  Default implementation of `c:OpenAPI.Renderer.render_type/2`.
+
   To the best of its ability, this function constructs an accurate typespec for the internal
   type given. Note that this is somewhat lossy; for example, many distinct types of strings will
   map to the `String.t()` type.
@@ -218,27 +221,29 @@ defmodule OpenAPI.Renderer.Util do
   def to_type(_state, {:string, _}), do: quote(do: String.t())
 
   # Complex Types
-  def to_type(state, {:array, type}) do
-    inner_type = to_type(state, type)
+  def to_type(%State{implementation: implementation} = state, {:array, type}) do
+    inner_type = implementation.render_type(state, type)
     quote(do: [unquote(inner_type)])
   end
 
   def to_type(_state, {:const, literal}) when is_binary(literal), do: quote(do: String.t())
   def to_type(_state, {:const, literal}), do: quote(do: unquote(literal))
 
-  def to_type(state, {:enum, literals}) do
-    to_type(state, {:union, Enum.map(literals, &{:const, &1})})
+  def to_type(%State{implementation: implementation} = state, {:enum, literals}) do
+    implementation.render_type(state, {:union, Enum.map(literals, &{:const, &1})})
   end
 
   def to_type(_state, {:union, []}), do: quote(do: nil)
-  def to_type(state, {:union, [type]}), do: to_type(state, type)
 
-  def to_type(state, {:union, types}) do
+  def to_type(%State{implementation: implementation} = state, {:union, [type]}),
+    do: implementation.render_type(state, type)
+
+  def to_type(%State{implementation: implementation} = state, {:union, types}) do
     types
     |> unwrap_unions()
     |> unwrap_enums()
     |> List.flatten()
-    |> Enum.map(&to_type(state, &1))
+    |> Enum.map(&implementation.render_type(state, &1))
     |> Enum.sort(&should_appear_in_this_order?/2)
     |> Enum.dedup()
     |> Enum.reduce(fn type, expression ->

--- a/lib/open_api/renderer/util.ex
+++ b/lib/open_api/renderer/util.ex
@@ -203,8 +203,11 @@ defmodule OpenAPI.Renderer.Util do
 
   # Primitives
   def to_type(_state, :boolean), do: quote(do: boolean)
+  def to_type(_state, {:boolean, _}), do: quote(do: boolean)
   def to_type(_state, :integer), do: quote(do: integer)
+  def to_type(_state, {:integer, _}), do: quote(do: integer)
   def to_type(_state, :number), do: quote(do: number)
+  def to_type(_state, {:number, _}), do: quote(do: number)
   def to_type(_state, :null), do: quote(do: nil)
 
   # Strings


### PR DESCRIPTION
This PR allows processing of custom formats for primitive types (`boolean`, `integer`, `number` and `string`). All non-`null` formats will be stored in a tuple (`{:string, "custom"}`).

The new callback `OpenAPI.Renderer.render_type/2` (with the default implementation in `OpenAPI.Renderer.Util.to_type/2`) is added to allow users to customize the formats' processing.