### PR TITLE
Add `:examples` key to OpenAPI.Spec.Schema

### DIFF
--- a/lib/open_api/spec/schema.ex
+++ b/lib/open_api/spec/schema.ex
@@ -59,6 +59,7 @@ defmodule OpenAPI.Spec.Schema do
           xml: Spec.Schema.XML.t(),
           external_docs: Spec.ExternalDocumentation.t() | nil,
           example: any,
+          examples: list() | nil,
           deprecated: boolean
         }
 
@@ -103,6 +104,7 @@ defmodule OpenAPI.Spec.Schema do
     :xml,
     :external_docs,
     :example,
+    :examples,
     :deprecated
   ]
 
@@ -184,6 +186,7 @@ defmodule OpenAPI.Spec.Schema do
       xml: xml,
       external_docs: docs,
       example: Map.get(yaml, "example"),
+      examples: Map.get(yaml, "examples"),
       deprecated: Map.get(yaml, "deprecated", false)
     }
 


### PR DESCRIPTION
`examples` key was added (and `example` is being deprecated) to Schema objects in OpenAPI 3.1.0.
> **Deprecated**: The example property has been deprecated in favor of the JSON Schema examples keyword. Use of example is discouraged, and later versions of this specification may remove it.

from https://spec.openapis.org/oas/latest.html?#fixed-fields-19

>  The value of this keyword MUST be an array. There are no restrictions placed on the values within the array. When multiple occurrences of this keyword are applicable to a single sub-instance, implementations MUST provide a flat array of all values rather than an array of arrays.
> This keyword can be used to provide sample JSON values associated with a particular schema, for the purpose of illustrating usage. It is RECOMMENDED that these values be valid against the associated schema.

from https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-9.5