### PR TITLE
Add names to arguments in functions' specs

### DIFF
--- a/lib/open_api/renderer/operation.ex
+++ b/lib/open_api/renderer/operation.ex
@@ -361,17 +361,17 @@ defmodule OpenAPI.Renderer.Operation do
     } = operation
 
     path_parameters =
-      for %Param{value_type: type} <- path_params do
-        quote(do: unquote(Util.to_type(state, type)))
+      for %Param{name: name, value_type: type} <- path_params do
+        quote(do: unquote({String.to_atom(name), [], nil}) :: unquote(Util.to_type(state, type)))
       end
 
     request_body =
       if length(request_body) > 0 do
         body_type = {:union, Enum.map(request_body, fn {_content_type, type} -> type end)}
-        quote(do: unquote(Util.to_type(state, body_type)))
+        quote(do: body :: unquote(Util.to_type(state, body_type)))
       end
 
-    opts = quote(do: keyword)
+    opts = quote(do: opts :: keyword)
 
     arguments = path_parameters ++ Enum.reject([request_body, opts], &is_nil/1)
     return_type = render_return_type(state, responses)


### PR DESCRIPTION
Instead of:
```
  @spec get_an_album(String.t(), keyword) ::
          {:ok, Example.AlbumObject.t()} | {:error, GitHub.Error.t()}
```
we'll now have:
```
  @spec get_an_album(id :: String.t(), opts :: keyword) ::
          {:ok, Example.AlbumObject.t()} | {:error, GitHub.Error.t()}
```

Motivation (from [Elixir documentation](https://hexdocs.pm/elixir/typespecs.html#defining-a-specification)):
>  This is particularly useful in documentation as a way to differentiate multiple arguments of the same type (or multiple elements of the same type in a type definition)