### PR TITLE
Module name generation when field name has `.` in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+* **Fix**: Module name generation when field name has `.` in it.
 
 ## 0.2.0 (2024-07-08)
 

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -659,7 +659,7 @@ defmodule OpenAPI.Processor.Naming do
           {parent_module, parent_type}
       end
 
-    module = Enum.join([inspect(parent_module), Macro.camelize(field_name)])
+    module = Enum.join([inspect(parent_module), Macro.camelize(String.replace(field_name, ".", "_"))])
     {module, to_string(parent_type)}
   end
 

--- a/test/fixture/dot-key-schema.yaml
+++ b/test/fixture/dot-key-schema.yaml
@@ -1,0 +1,61 @@
+openapi: "3.1.0"
+info:
+  title: Spec with Sub Schema
+  version: 1
+paths:
+  "/example":
+    get:
+      description: "Example endpoint"
+      operationId: example
+      summary: "Example endpoint"
+      responses:
+        "200":
+          description: "Success"
+          content:
+            "application/json":
+              schema:
+                "$ref": "#/components/schemas/user"
+components:
+  schemas:
+    user:
+      type: object
+      properties:
+        id:
+          type: integer
+        team:
+          type: object
+          properties:
+            
+            api_key.created:
+              type: object
+              properties:
+                id:
+                  type: string
+                data:
+                  type: object
+                  properties:
+                    scopes:
+                      type: array
+                      items:
+                        type: string
+            api_key.updated:
+              type: object
+              properties:
+                id:
+                  type: string
+                changes_requested:
+                  type: object
+                  properties:
+                    scopes:
+                      type: array
+                      items:
+                        type: string
+            api_key.deleted:
+              type: object
+              properties:
+                id:
+                  type: string            
+
+      required:
+        - id
+        - team

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -145,4 +145,48 @@ defmodule OpenAPI.Processor.NamingTest do
       assert Naming.normalize_identifier("OpenAPISpec", :camel) == "OpenAPISpec"
     end
   end
+
+  describe "raw_schema_module_and_type/3" do
+    test "returns schema module and type", %{state: state} do
+      state = state
+        |> Map.put(:implementation, OpenAPI.Processor)
+        |> Map.put(:schemas_by_ref, %{
+          "ref" => %OpenAPI.Processor.Schema{
+            ref: "ref",
+            module_name: SchemaModuleName,
+            type_name: "t"
+          }
+        })
+        |> Map.put(:schema_specs_by_ref, %{"ref" => %OpenAPI.Spec.Schema{}})
+
+      assert Naming.raw_schema_module_and_type(
+        state,
+        %OpenAPI.Processor.Schema{
+          context: [{:field, "ref", "test"}]
+        },
+        %OpenAPI.Spec.Schema{}
+      ) == {"SchemaModuleNameTest", "t"}
+    end
+
+    test "returns schema module and type when field has a `.` in the name", %{state: state} do
+      state = state
+        |> Map.put(:implementation, OpenAPI.Processor)
+        |> Map.put(:schemas_by_ref, %{
+          "ref" => %OpenAPI.Processor.Schema{
+            ref: "ref",
+            module_name: SchemaModuleName,
+            type_name: "t"
+          }
+        })
+        |> Map.put(:schema_specs_by_ref, %{"ref" => %OpenAPI.Spec.Schema{}})
+
+      assert Naming.raw_schema_module_and_type(
+        state,
+        %OpenAPI.Processor.Schema{
+          context: [{:field, "ref", "test.field"}]
+        },
+        %OpenAPI.Spec.Schema{}
+      ) == {"SchemaModuleNameTestField", "t"}
+    end
+  end
 end


### PR DESCRIPTION
## Issue  
In the OpenAI API YAML file, certain field names contain dots (`.`), such as:  
[`api_key.created:`](https://github.com/openai/openai-openapi/blob/ec54f8876168475efa70effa31d4e6cff122c053/openapi.yaml#L14354)  

This results in incorrect module name generation and leads to the following error:  
```
** (File.Error) could not make directory (with -p) "lib/v2/schemas/:\"_elixir/audit_log/user": no such file or directory
    (elixir 1.18.1) lib/file.ex:346: File.mkdir_p!/1
    (oapi_generator 0.2.0) lib/open_api/renderer/util.ex:346: OpenAPI.Renderer.Util.write/2
    (oapi_generator 0.2.0) lib/open_api/renderer.ex:386: anonymous fn/3 in OpenAPI.Renderer.render_files/1
    (stdlib 5.2.3.2) maps.erl:416: :maps.fold_1/4
    (oapi_generator 0.2.0) lib/open_api/renderer.ex:20: OpenAPI.Renderer.run/1
    (mix 1.18.1) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5  
    (mix 1.18.1) lib/mix/task.ex:561: Mix.Task.run_alias/6
    (mix 1.18.1) lib/mix/cli.ex:107: Mix.CLI.run_task/2
```

## Solution  
This PR updates the **`OpenAPI.Processor.Naming`** module to correctly handle field names with dots by replacing them with underscores. Additionally, tests and fixtures have been added to ensure proper module name generation.  

## Changes  

### Fixes and Improvements  
- **[`lib/open_api/processor/naming.ex`](diffhunk://#diff-b68cd8c460a0deaed0deab4c386a61b1fd266ff683b74a8ddc61858c25e6707bL662-R662)**  
  - Updated module name generation logic to replace dots in field names with underscores.  
- **[`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R10)**  
  - Documented the fix for handling dots in field names.  

### Tests and Fixtures  
- **[`test/open_api/processor/naming_test.exs`](diffhunk://#diff-45ba2a2405e9db66913bef7b00dee86d1a4735f3fd100fa274527c104dcd6ff9R148-R191)**  
  - Added test cases to validate module name generation for field names containing dots.  
- **[`test/fixture/dot-key-schema.yaml`](diffhunk://#diff-3d40dfc7285c178b84c7e25ad1ec57a29d7b88f914f23ffa95c3a5a8a26bb9e2R1-R61)**  
  - Added a fixture file with example schema containing dotted field names.  ATM tests don't use fixtures