### PR TITLE
Ensure Response Subfield Schemas are Output

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.1-otp-27
-erlang 27.0
+elixir 1.18.3-otp-27
+erlang 27.3.3

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -650,17 +650,18 @@ defmodule OpenAPI.Processor.Naming do
       ) do
     %State{implementation: implementation, schemas_by_ref: schemas_by_ref} = state
 
-    {parent_module, parent_type} =
-      case Map.fetch!(schemas_by_ref, parent_ref) do
-        %Schema{module_name: nil, type_name: nil} = parent ->
-          implementation.schema_module_and_type(state, parent)
+    case Map.fetch!(schemas_by_ref, parent_ref) do
+      %Schema{module_name: nil, type_name: nil} = parent ->
+        implementation.schema_module_and_type(state, parent)
 
-        %Schema{module_name: parent_module, type_name: parent_type} ->
-          {parent_module, parent_type}
-      end
+      %Schema{module_name: parent_module, type_name: "t"} ->
+        module = Enum.join([inspect(parent_module), normalize_identifier(field_name, :camel)])
+        {module, "t"}
 
-    module = Enum.join([inspect(parent_module), normalize_identifier(field_name, :camel)])
-    {module, to_string(parent_type)}
+      %Schema{module_name: parent_module, type_name: parent_type} ->
+        type = Enum.join([to_string(parent_type), normalize_identifier(field_name, :snake)], "_")
+        {inspect(parent_module), type}
+    end
   end
 
   def raw_schema_module_and_type(_state, _schema, _schema_spec) do

--- a/lib/open_api/renderer/operation.ex
+++ b/lib/open_api/renderer/operation.ex
@@ -59,22 +59,13 @@ defmodule OpenAPI.Renderer.Operation do
     related_schemas =
       schemas
       |> Enum.filter(&(&1.output_format == :typed_map))
-      |> Enum.filter(fn
-        # %Schema{context: [{:request, ^module, _, _}]} -> true
-        %Schema{context: [{:response, ^module, _, _, _}]} -> true
-        _else -> false
-      end)
+      |> filter_related_schemas(state, module)
       |> Enum.group_by(&{&1.module_name, &1.type_name})
       |> Enum.map(fn {_module_and_type, schemas} -> Enum.reduce(schemas, &Schema.merge/2) end)
       |> List.flatten()
       |> Enum.sort_by(& &1.type_name)
 
-    related_schemas_by_operation =
-      Enum.group_by(related_schemas, fn
-        # %Schema{context: [{:request, ^module, operation_name, _}]} -> operation_name
-        %Schema{context: [{:response, ^module, operation_name, _, _}]} -> operation_name
-        _else -> :unknown
-      end)
+    related_schemas_by_operation = group_related_schemas(related_schemas, state)
 
     for operation <- Enum.sort_by(operations, & &1.function_name) do
       related_schemas = related_schemas_by_operation[operation.function_name] || []
@@ -83,6 +74,148 @@ defmodule OpenAPI.Renderer.Operation do
         implementation.render_schema_types(state, related_schemas),
         implementation.render_operation(state, operation)
       ])
+    end
+  end
+
+  defp filter_related_schemas(schemas, state, module) do
+    to_process =
+      schemas
+      |> Enum.filter(&(&1.output_format == :typed_map))
+      |> :queue.from_list()
+
+    do_filter_related_schemas(
+      %{schemas_by_ref: state.schemas, module: module, filter_by_ref: %{}, final: []},
+      to_process
+    )
+  end
+
+  defp do_filter_related_schemas(
+         %{
+           schemas_by_ref: schemas_by_ref,
+           module: module,
+           filter_by_ref: filter_by_ref,
+           final: final
+         },
+         to_process
+       ) do
+    case :queue.out(to_process) do
+      {{:value, %Schema{context: [{:response, ^module, _, _, _}], ref: ref} = schema}, to_process} ->
+        do_filter_related_schemas(
+          %{
+            schemas_by_ref: schemas_by_ref,
+            module: module,
+            filter_by_ref: Map.put(filter_by_ref, ref, true),
+            final: [schema | final]
+          },
+          to_process
+        )
+
+      {{:value, %Schema{context: [{:field, parent_ref, _}], ref: ref} = schema}, to_process} ->
+        case Map.fetch(filter_by_ref, parent_ref) do
+          {:ok, true} ->
+            do_filter_related_schemas(
+              %{
+                schemas_by_ref: schemas_by_ref,
+                module: module,
+                filter_by_ref: Map.put(filter_by_ref, ref, true),
+                final: [schema | final]
+              },
+              to_process
+            )
+
+          {:ok, false} ->
+            do_filter_related_schemas(
+              %{
+                schemas_by_ref: schemas_by_ref,
+                module: module,
+                filter_by_ref: Map.put(filter_by_ref, ref, false),
+                final: final
+              },
+              to_process
+            )
+
+          :error ->
+            to_process = :queue.in(schema, to_process)
+
+            do_filter_related_schemas(
+              %{
+                schemas_by_ref: schemas_by_ref,
+                module: module,
+                filter_by_ref: filter_by_ref,
+                final: final
+              },
+              to_process
+            )
+        end
+
+      {{:value, %Schema{ref: ref}}, to_process} ->
+        do_filter_related_schemas(
+          %{
+            schemas_by_ref: schemas_by_ref,
+            module: module,
+            filter_by_ref: Map.put(filter_by_ref, ref, false),
+            final: final
+          },
+          to_process
+        )
+
+      {:empty, _to_process} ->
+        final
+    end
+  end
+
+  defp group_related_schemas(schemas, state) do
+    do_group_related_schemas(
+      %{schemas_by_ref: state.schemas, group_by_ref: %{}, final: %{}},
+      :queue.from_list(schemas)
+    )
+  end
+
+  defp do_group_related_schemas(
+         %{
+           schemas_by_ref: schemas_by_ref,
+           group_by_ref: group_by_ref,
+           final: final
+         },
+         to_process
+       ) do
+    case :queue.out(to_process) do
+      {{:value, %Schema{context: [{:response, _, operation, _, _}], ref: ref} = schema},
+       to_process} ->
+        do_group_related_schemas(
+          %{
+            schemas_by_ref: schemas_by_ref,
+            group_by_ref: Map.put(group_by_ref, ref, operation),
+            final: Map.update(final, operation, [schema], fn schemas -> [schema | schemas] end)
+          },
+          to_process
+        )
+
+      {{:value, %Schema{context: [{:field, parent_ref, _}], ref: ref} = schema}, to_process} ->
+        if operation = Map.get(group_by_ref, parent_ref) do
+          do_group_related_schemas(
+            %{
+              schemas_by_ref: schemas_by_ref,
+              group_by_ref: Map.put(group_by_ref, ref, operation),
+              final: Map.update(final, operation, [schema], fn schemas -> [schema | schemas] end)
+            },
+            to_process
+          )
+        else
+          to_process = :queue.in(schema, to_process)
+
+          do_group_related_schemas(
+            %{
+              schemas_by_ref: schemas_by_ref,
+              group_by_ref: group_by_ref,
+              final: final
+            },
+            to_process
+          )
+        end
+
+      {:empty, _to_process} ->
+        final
     end
   end
 

--- a/lib/open_api/renderer/schema.ex
+++ b/lib/open_api/renderer/schema.ex
@@ -84,6 +84,7 @@ defmodule OpenAPI.Renderer.Schema do
         %Schema{output_format: :struct} -> true
         # %Schema{context: [{:request, ^module, _, _}]} -> true
         %Schema{context: [{:response, ^module, _, _, _}], output_format: :typed_map} -> true
+        %Schema{context: [{:field, _, _}], output_format: :typed_map} -> true
         _else -> false
       end)
       |> Enum.group_by(&{&1.module_name, &1.type_name})


### PR DESCRIPTION
This PR focuses on situations in which responses are inline schemas with inline subfields (or, more generally, schemas used only in this response). Previously, the types for these schemas were not named correctly, and the related data (typespec and field definition) were omitted from the operation module.

Work in progress.