### PR TITLE
Rename operation modules using the same rules as schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Breaking**: Officially drop support for Elixir 1.14 (and lower) and Erlang/OTP 23 (and lower).
   Elixir 1.15+ and Erlang/OTP 24+ are supported.
+* **Breaking**: Operation modules are now renamed using the same `naming.rename` configuration as schema modules.
 
 * **Add**: Processor and Renderer modules now have proper `@behaviour` and `@impl` annotations.
   Thanks [@McSym28](https://github.com/aj-foster/open-api-generator/pull/70)!


### PR DESCRIPTION
This PR resolves an issue where operation modules may have different names than the schemas output within them due to renaming rules. I'm not 100% sure this is the best way to accomplish this, but it's a start.