### PR TITLE
requestBody $ref Handling

### DIFF
--- a/lib/open_api/spec/request_body.ex
+++ b/lib/open_api/spec/request_body.ex
@@ -44,5 +44,15 @@ defmodule OpenAPI.Spec.RequestBody do
     end)
   end
 
+  defp decode_content(state, %{"$ref" => _} = yaml) do
+    with_ref(state, yaml, fn state, yaml ->
+      if Map.has_key?(yaml, "content") do
+        decode_content(state, yaml)
+      else
+        {state, %{}}
+      end
+    end)
+  end
+
   defp decode_content(state, _yaml), do: {state, %{}}
 end


### PR DESCRIPTION
According to the current OpenAPI [specification](https://swagger.io/specification/), the [Operation Object](https://swagger.io/specification/#operation-object) requestBody field can also be a Reference Object. This will handle {"$ref": "..."} here.
