### PR TITLE
Fall back to map type when additionalProperties is a schema

### DIFF
--- a/lib/open_api/processor/type.ex
+++ b/lib/open_api/processor/type.ex
@@ -150,6 +150,11 @@ defmodule OpenAPI.Processor.Type do
     {state, :map}
   end
 
+  def from_schema(state, %Schema{additional_properties: %Schema{}, properties: properties})
+      when map_size(properties) == 0 do
+    {state, :map}
+  end
+
   def from_schema(state, %Schema{} = schema_spec) do
     State.put_schema_spec(state, schema_spec)
   end


### PR DESCRIPTION
Based on feedback from #75, this change will force schemas to fall back to a `map` type when they only have `additionalProperties` defined as a schema.