### PR TITLE
renderer: add error_fallback config for undocumented error responses

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -313,6 +313,14 @@ Remember that all configuration values must be contained within a profile.
   By default, the error type is a union of all possible error responses for the operation.
   See `OpenAPI.Renderer.Operation.render_spec/2` for more information.
 
+- `output.types.error_fallback`: Type to append to the error union when undocumented error responses exist.
+  Some OpenAPI specs define error status codes (4xx, 5xx) without response schemas.
+  These undocumented errors are excluded from typespecs by default, creating a mismatch between
+  the typespec and possible runtime values. This option adds a fallback type to the union.
+  Example: `{:string, :generic}` adds `String.t()` to handle undocumented errors.
+  Has no effect when `output.types.error` is set (which overrides all error types).
+  See `OpenAPI.Renderer.Operation.render_spec/2` for more information.
+
 - `output.types.specs`: Format of type specifications to use for operation functions.
   The default is `:spec`, which outputs a single `@spec` including all arguments and `opts`.
   Use `:spec_comprehensive` to output two `@spec`, one with and one without the optional `opts` parameter.

--- a/lib/open_api/renderer/operation.ex
+++ b/lib/open_api/renderer/operation.ex
@@ -682,6 +682,11 @@ defmodule OpenAPI.Renderer.Operation do
   defp render_return_type(state, responses) do
     %State{implementation: implementation} = state
 
+    has_undocumented_errors =
+      Enum.any?(responses, fn {status, schemas} ->
+        status >= 400 and map_size(schemas) == 0
+      end)
+
     {success, error} =
       responses
       |> Enum.reject(fn {_status, schemas} -> map_size(schemas) == 0 end)
@@ -705,13 +710,17 @@ defmodule OpenAPI.Renderer.Operation do
       if error_type = config(state)[:types][:error] do
         quote(do: {:error, unquote(implementation.render_type(state, error_type))})
       else
-        if length(error) > 0 do
-          type =
-            error
-            |> Enum.map(fn {_state, schemas} -> Map.values(schemas) end)
-            |> List.flatten()
-            |> then(&implementation.render_type(state, {:union, &1}))
+        fallback = config(state)[:types][:error_fallback]
 
+        error_types =
+          error
+          |> Enum.flat_map(fn {_status, schemas} -> Map.values(schemas) end)
+          |> then(fn types ->
+            if has_undocumented_errors && fallback, do: types ++ [fallback], else: types
+          end)
+
+        if length(error_types) > 0 do
+          type = implementation.render_type(state, {:union, error_types})
           quote(do: {:error, unquote(type)})
         else
           quote(do: :error)

--- a/test/open_api/renderer/operation_test.exs
+++ b/test/open_api/renderer/operation_test.exs
@@ -1,0 +1,193 @@
+defmodule OpenAPI.Renderer.OperationTest do
+  use ExUnit.Case, async: true
+
+  alias OpenAPI.Processor.Operation
+  alias OpenAPI.Renderer.Operation, as: OperationRenderer
+  alias OpenAPI.Renderer.State
+
+  describe "render_spec/2 error_fallback" do
+    test "includes fallback type when undocumented errors exist and error_fallback is configured" do
+      profile = :test_fallback_with_undocumented
+      put_test_config(profile, error_fallback: {:string, :generic})
+
+      state = %State{
+        files: %{},
+        implementation: OpenAPI.Renderer,
+        operations: [],
+        profile: profile,
+        schemas: %{}
+      }
+
+      operation = %Operation{
+        docstring: "Test",
+        function_name: :test_op,
+        module_name: Test.Ops,
+        request_body: [],
+        request_method: :get,
+        request_path: "/test",
+        request_path_parameters: [],
+        request_query_parameters: [],
+        responses: [
+          {200, %{"application/json" => :map}},
+          {400, %{}},
+          {422, %{"application/json" => {Test.ValidationError, :t}}}
+        ]
+      }
+
+      spec = OperationRenderer.render_spec(state, operation)
+      spec_string = Macro.to_string(spec)
+
+      assert spec_string =~ "String.t()"
+      assert spec_string =~ "Test.ValidationError.t()"
+    end
+
+    test "does not include fallback when no undocumented errors exist" do
+      profile = :test_fallback_all_documented
+      put_test_config(profile, error_fallback: {:string, :generic})
+
+      state = %State{
+        files: %{},
+        implementation: OpenAPI.Renderer,
+        operations: [],
+        profile: profile,
+        schemas: %{}
+      }
+
+      operation = %Operation{
+        docstring: "Test",
+        function_name: :test_op,
+        module_name: Test.Ops,
+        request_body: [],
+        request_method: :get,
+        request_path: "/test",
+        request_path_parameters: [],
+        request_query_parameters: [],
+        responses: [
+          {200, %{"application/json" => :map}},
+          {422, %{"application/json" => {Test.ValidationError, :t}}}
+        ]
+      }
+
+      spec = OperationRenderer.render_spec(state, operation)
+      spec_string = Macro.to_string(spec)
+
+      assert spec_string =~ "Test.ValidationError.t()"
+      refute spec_string =~ "| String.t()"
+    end
+
+    test "does not include fallback when error_fallback is not configured" do
+      profile = :test_no_fallback_config
+      put_test_config(profile, [])
+
+      state = %State{
+        files: %{},
+        implementation: OpenAPI.Renderer,
+        operations: [],
+        profile: profile,
+        schemas: %{}
+      }
+
+      operation = %Operation{
+        docstring: "Test",
+        function_name: :test_op,
+        module_name: Test.Ops,
+        request_body: [],
+        request_method: :get,
+        request_path: "/test",
+        request_path_parameters: [],
+        request_query_parameters: [],
+        responses: [
+          {200, %{"application/json" => :map}},
+          {400, %{}},
+          {422, %{"application/json" => {Test.ValidationError, :t}}}
+        ]
+      }
+
+      spec = OperationRenderer.render_spec(state, operation)
+      spec_string = Macro.to_string(spec)
+
+      assert spec_string =~ "Test.ValidationError.t()"
+      refute spec_string =~ "String.t()"
+    end
+
+    test "fallback works when only undocumented errors exist" do
+      profile = :test_fallback_only_undocumented
+      put_test_config(profile, error_fallback: {:string, :generic})
+
+      state = %State{
+        files: %{},
+        implementation: OpenAPI.Renderer,
+        operations: [],
+        profile: profile,
+        schemas: %{}
+      }
+
+      operation = %Operation{
+        docstring: "Test",
+        function_name: :test_op,
+        module_name: Test.Ops,
+        request_body: [],
+        request_method: :get,
+        request_path: "/test",
+        request_path_parameters: [],
+        request_query_parameters: [],
+        responses: [
+          {200, %{"application/json" => :map}},
+          {400, %{}},
+          {401, %{}},
+          {500, %{}}
+        ]
+      }
+
+      spec = OperationRenderer.render_spec(state, operation)
+      spec_string = Macro.to_string(spec)
+
+      assert spec_string =~ "{:error, String.t()}"
+    end
+
+    test "types.error overrides error_fallback" do
+      profile = :test_error_overrides_fallback
+      put_test_config(profile, error: {Test.Error, :t}, error_fallback: {:string, :generic})
+
+      state = %State{
+        files: %{},
+        implementation: OpenAPI.Renderer,
+        operations: [],
+        profile: profile,
+        schemas: %{}
+      }
+
+      operation = %Operation{
+        docstring: "Test",
+        function_name: :test_op,
+        module_name: Test.Ops,
+        request_body: [],
+        request_method: :get,
+        request_path: "/test",
+        request_path_parameters: [],
+        request_query_parameters: [],
+        responses: [
+          {200, %{"application/json" => :map}},
+          {400, %{}},
+          {422, %{"application/json" => {Test.ValidationError, :t}}}
+        ]
+      }
+
+      spec = OperationRenderer.render_spec(state, operation)
+      spec_string = Macro.to_string(spec)
+
+      assert spec_string =~ "Test.Error.t()"
+      refute spec_string =~ "String.t()"
+      refute spec_string =~ "Test.ValidationError.t()"
+    end
+  end
+
+  defp put_test_config(profile, types_opts) do
+    Application.put_env(:oapi_generator, profile,
+      output: [
+        base_module: Test,
+        types: types_opts
+      ]
+    )
+  end
+end


### PR DESCRIPTION
Some OpenAPI specs define error status codes (4xx, 5xx) without response schemas. Previously, these undocumented errors were filtered out when generating typespecs, creating a mismatch between the typespec and possible runtime values.

Add `output.types.error_fallback` configuration option that appends a fallback type to the error union when undocumented error responses exist. This allows generated clients to satisfy Dialyzer while handling APIs that don't fully document their error responses.

Example config:
```
  output: [types: [error_fallback: {:string, :generic}]]
```

Generates:
```
  @spec get_customer(String.t(), keyword) ::
    {:ok, Customer.t()} | {:error, HTTPValidationError.t() | String.t()}
```