### PR TITLE
Fix rename bug

### DIFF
--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -126,7 +126,7 @@ defmodule OpenAPI.Processor.Naming do
         modules
         |> Enum.map(fn module ->
           normalize_identifier(module, :camel)
-          |> do_rename_schema(state)
+          |> rename_schema(state)
         end)
         |> Module.concat()
       end
@@ -138,7 +138,7 @@ defmodule OpenAPI.Processor.Naming do
           |> String.split("/", trim: true)
           |> Enum.map(fn module ->
             normalize_identifier(module, :camel)
-            |> do_rename_schema(state)
+            |> rename_schema(state)
           end)
           |> Module.concat()
         end)
@@ -230,7 +230,6 @@ defmodule OpenAPI.Processor.Naming do
     {module, type} =
       raw_schema_module_and_type(state, schema, schema_spec)
       |> merge_schema(state)
-      |> rename_schema(state)
       |> group_schema(state)
 
     if is_nil(module) do
@@ -402,15 +401,11 @@ defmodule OpenAPI.Processor.Naming do
   use capture expressions (ex. `~r/(Api)([A-Z]|$)/`) and replacements that reference those
   captures (ex. `"API\\\\2"`). See `String.replace/3` for more information.
   """
-  @spec rename_schema(raw_module_and_type, State.t()) :: raw_module_and_type
-  def rename_schema(raw_module_and_type, state)
-  def rename_schema({nil, type}, _state), do: {nil, type}
+  @spec rename_schema(module, State.t()) :: module
+  def rename_schema(raw_module, state)
+  def rename_schema(nil, _state), do: nil
 
-  def rename_schema({module, type}, state) do
-    {do_rename_schema(module, state), type}
-  end
-
-  defp do_rename_schema(module, state) do
+  def rename_schema(module, state) do
     replacements = config(state)[:rename] || []
 
     Enum.reduce(replacements, module, fn {pattern, replacement}, module ->
@@ -696,6 +691,8 @@ defmodule OpenAPI.Processor.Naming do
         %Schema{module_name: parent_module, type_name: parent_type} ->
           {inspect(parent_module), to_string(parent_type)}
       end
+
+    field_name = rename_schema(field_name, state)
 
     module = Enum.join([parent_module, normalize_identifier(field_name, :camel)])
     {module, parent_type}

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -48,19 +48,19 @@ defmodule OpenAPI.Processor.Naming do
   """
   @doc default_implementation: true
   @spec operation_function(State.t(), OperationSpec.t()) :: atom
-  def operation_function(_state, %OperationSpec{operation_id: id}) when not is_nil(id) do
+  def operation_function(state, %OperationSpec{operation_id: id}) when not is_nil(id) do
     id
     |> String.split("/", trim: true)
     |> List.last()
-    |> normalize_identifier()
+    |> normalize_identifier(state)
     |> String.to_atom()
   end
 
-  def operation_function(_state, operation_spec) do
+  def operation_function(state, operation_spec) do
     %OperationSpec{"$oag_path": path, "$oag_path_method": method} = operation_spec
 
     "#{path}_#{method}"
-    |> normalize_identifier()
+    |> normalize_identifier(state)
     |> String.to_atom()
   end
 
@@ -125,8 +125,7 @@ defmodule OpenAPI.Processor.Naming do
       if length(modules) > 0 do
         modules
         |> Enum.map(fn module ->
-          normalize_identifier(module, :camel)
-          |> rename_schema(state)
+          normalize_identifier(module, state, :camel)
         end)
         |> Module.concat()
       end
@@ -137,8 +136,7 @@ defmodule OpenAPI.Processor.Naming do
           tag
           |> String.split("/", trim: true)
           |> Enum.map(fn module ->
-            normalize_identifier(module, :camel)
-            |> rename_schema(state)
+            normalize_identifier(module, state, :camel)
           end)
           |> Module.concat()
         end)
@@ -500,21 +498,22 @@ defmodule OpenAPI.Processor.Naming do
 
   ## Example
 
-      iex> normalize_identifier("get-/customer/purchases/{date}_byId")
+      iex> normalize_identifier("get-/customer/purchases/{date}_byId", %OpenAPI.Processor.State{})
       "get_customer_purchases_date_by_id"
 
-      iex> normalize_identifier("openAPISpec", :camel)
+      iex> normalize_identifier("openAPISpec", %OpenAPI.Processor.State{}, :camel)
       "OpenAPISpec"
 
-      iex> normalize_identifier("get-/customer/purchases/{date}_byId", :lower_camel)
+      iex> normalize_identifier("get-/customer/purchases/{date}_byId", %OpenAPI.Processor.State{}, :lower_camel)
       "getCustomerPurchasesDateById"
 
   """
-  @spec normalize_identifier(String.t(), :camel | :lower_camel | :snake) :: String.t()
-  def normalize_identifier(input, casing \\ :snake)
+  @spec normalize_identifier(String.t(), State.t(), :camel | :lower_camel | :snake) :: String.t()
+  def normalize_identifier(input, state, casing \\ :snake)
 
-  def normalize_identifier(input, :camel) do
+  def normalize_identifier(input, state, :camel) do
     input
+    |> rename_schema(state)
     |> segment_identifier()
     |> Enum.map(fn segment ->
       if String.match?(segment, ~r/^[A-Z]+$/) do
@@ -526,8 +525,8 @@ defmodule OpenAPI.Processor.Naming do
     |> Enum.join()
   end
 
-  def normalize_identifier(input, :lower_camel) do
-    [first_segment | segments] = segment_identifier(input)
+  def normalize_identifier(input, state, :lower_camel) do
+    [first_segment | segments] = input |> rename_schema(state) |> segment_identifier()
 
     segments =
       Enum.map(segments, fn segment ->
@@ -541,8 +540,9 @@ defmodule OpenAPI.Processor.Naming do
     Enum.join([first_segment | segments])
   end
 
-  def normalize_identifier(input, :snake) do
+  def normalize_identifier(input, state, :snake) do
     input
+    |> rename_schema(state)
     |> segment_identifier()
     |> Enum.map_join("_", &String.downcase/1)
   end
@@ -598,33 +598,33 @@ defmodule OpenAPI.Processor.Naming do
           {module :: String.t() | nil, type :: String.t()}
   def raw_schema_module_and_type(state, schema, schema_spec)
 
-  def raw_schema_module_and_type(_state, _schema, %SchemaSpec{
+  def raw_schema_module_and_type(state, _schema, %SchemaSpec{
         "$oag_last_ref_file": filename,
         "$oag_last_ref_path": []
       }) do
     module =
       filename
       |> Path.basename(Path.extname(filename))
-      |> normalize_identifier(:camel)
+      |> normalize_identifier(state, :camel)
 
     {module, "t"}
   end
 
-  def raw_schema_module_and_type(_state, _schema, %SchemaSpec{
+  def raw_schema_module_and_type(state, _schema, %SchemaSpec{
         "$oag_last_ref_path": ["components", "schemas", schema_name]
       }) do
-    module = normalize_identifier(schema_name, :camel)
+    module = normalize_identifier(schema_name, state, :camel)
     {module, "t"}
   end
 
-  def raw_schema_module_and_type(_state, _schema, %SchemaSpec{
+  def raw_schema_module_and_type(state, _schema, %SchemaSpec{
         "$oag_last_ref_path": ["components", "schemas", schema_name, "items"]
       }) do
-    module = normalize_identifier(schema_name, :camel)
+    module = normalize_identifier(schema_name, state, :camel)
     {module, "t"}
   end
 
-  def raw_schema_module_and_type(_state, _schema, %SchemaSpec{
+  def raw_schema_module_and_type(state, _schema, %SchemaSpec{
         "$oag_last_ref_path": [
           "components",
           "responses",
@@ -634,7 +634,7 @@ defmodule OpenAPI.Processor.Naming do
           "schema"
         ]
       }) do
-    module = normalize_identifier(schema_name, :camel)
+    module = normalize_identifier(schema_name, state, :camel)
     type = Enum.join([readable_content_type(content_type), "resp"], "_")
 
     {module, type}
@@ -669,9 +669,9 @@ defmodule OpenAPI.Processor.Naming do
     {inspect(op_module), type}
   end
 
-  def raw_schema_module_and_type(_state, _schema, %SchemaSpec{title: schema_title})
+  def raw_schema_module_and_type(state, _schema, %SchemaSpec{title: schema_title})
       when is_binary(schema_title) do
-    module = normalize_identifier(schema_title, :camel)
+    module = normalize_identifier(schema_title, state, :camel)
     {module, "t"}
   end
 
@@ -692,9 +692,7 @@ defmodule OpenAPI.Processor.Naming do
           {inspect(parent_module), to_string(parent_type)}
       end
 
-    field_name = rename_schema(field_name, state)
-
-    module = Enum.join([parent_module, normalize_identifier(field_name, :camel)])
+    module = Enum.join([parent_module, normalize_identifier(field_name, state, :camel)])
     {module, parent_type}
   end
 
@@ -715,7 +713,7 @@ defmodule OpenAPI.Processor.Naming do
           {inspect(parent_module), to_string(parent_type)}
       end
 
-    type = Enum.join([parent_type, normalize_identifier(field_name, :snake)], "_")
+    type = Enum.join([parent_type, normalize_identifier(field_name, state, :snake)], "_")
     {parent_module, type}
   end
 

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -572,7 +572,7 @@ defmodule OpenAPI.Processor.Naming do
   end
 
   defp raise_for_invalid_identifier(input) do
-    if !String.match?(input, ~r/^[A-Za-z][A-Za-z0-9]+$/) do
+    if String.match?(input, ~r/^[^A-Za-z]+$/) do
       raise ArgumentError, """
       Identifier #{input} cannot be normalized
 

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -572,7 +572,7 @@ defmodule OpenAPI.Processor.Naming do
   end
 
   defp raise_for_invalid_identifier(input) do
-    if String.match?(input, ~r/^[^A-Za-z]+$/) do
+    if !String.match?(input, ~r/^[A-Za-z][A-Za-z0-9]+$/) do
       raise ArgumentError, """
       Identifier #{input} cannot be normalized
 

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -572,7 +572,7 @@ defmodule OpenAPI.Processor.Naming do
   end
 
   defp raise_for_invalid_identifier(input) do
-    if String.match?(input, ~r/^[^A-Za-z]+$/) do
+    if String.match?(input, ~r/^[^A-Za-z0-9]+$/) do
       raise ArgumentError, """
       Identifier #{input} cannot be normalized
 

--- a/lib/open_api/processor/naming.ex
+++ b/lib/open_api/processor/naming.ex
@@ -572,7 +572,7 @@ defmodule OpenAPI.Processor.Naming do
   end
 
   defp raise_for_invalid_identifier(input) do
-    if String.match?(input, ~r/^[^A-Za-z0-9]+$/) do
+    if String.match?(input, ~r/^[^A-Za-z]+$/) do
       raise ArgumentError, """
       Identifier #{input} cannot be normalized
 

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -156,26 +156,57 @@ defmodule OpenAPI.Processor.NamingTest do
     end
   end
 
-  describe "raw_schema_module_and_type/3" do
-    setup context do
-      Map.update!(context, :state, fn state ->
-        state
-        |> Map.put(:implementation, OpenAPI.Processor)
-        |> Map.put(:schemas_by_ref, %{
-          "ref" => %OpenAPI.Processor.Schema{
-            ref: "ref",
-            module_name: SchemaModuleName,
-            type_name: "t"
-          },
-          "sub_ref" => %OpenAPI.Processor.Schema{
-            ref: "sub_ref",
-            module_name: SchemaModuleName,
-            type_name: "something_else"
-          }
-        })
-        |> Map.put(:schema_specs_by_ref, %{"ref" => %OpenAPI.Spec.Schema{}})
-      end)
+  defp setup_for_schema_module_and_type(context) do
+    Map.update!(context, :state, fn state ->
+      state
+      |> Map.put(:implementation, OpenAPI.Processor)
+      |> Map.put(:schemas_by_ref, %{
+        "ref" => %OpenAPI.Processor.Schema{
+          ref: "ref",
+          module_name: SchemaModuleName,
+          type_name: "t"
+        },
+        "sub_ref" => %OpenAPI.Processor.Schema{
+          ref: "sub_ref",
+          module_name: SchemaModuleName,
+          type_name: "something_else"
+        }
+      })
+      |> Map.put(:schema_specs_by_ref, %{"ref" => %OpenAPI.Spec.Schema{}})
+    end)
+  end
+
+  describe "schema_module_and_type/2" do
+    setup :setup_for_schema_module_and_type
+
+    test "returns schema module and type", %{state: state} do
+      assert Naming.schema_module_and_type(
+               state,
+               %OpenAPI.Processor.Schema{
+                 context: [{:field, "ref", "test"}],
+                 output_format: :struct,
+                 ref: "ref"
+               }
+             ) == {SchemaModuleNameTest, :t}
     end
+
+    test "does not raise when numerical identifier is renamed", context do
+      %{state: state} = context
+      Application.put_env(:oapi_generator, @profile, naming: [rename: [{"123", "S123"}]])
+
+      assert Naming.schema_module_and_type(
+               state,
+               %OpenAPI.Processor.Schema{
+                 context: [{:field, "ref", "123"}],
+                 output_format: :struct,
+                 ref: "ref"
+               }
+             ) == {SchemaModuleNameTest, :s123}
+    end
+  end
+
+  describe "raw_schema_module_and_type/3" do
+    setup :setup_for_schema_module_and_type
 
     test "returns schema module and type", %{state: state} do
       assert Naming.raw_schema_module_and_type(
@@ -242,20 +273,6 @@ defmodule OpenAPI.Processor.NamingTest do
                },
                %OpenAPI.Spec.Schema{}
              ) == {"SchemaModuleName", "something_else_test_field"}
-    end
-
-    test "does not raise when numerical identifier is renamed", context do
-      %{state: state} = context
-      Application.put_env(:oapi_generator, @profile, naming: [rename: [{"123", "S123"}]])
-
-      assert Naming.raw_schema_module_and_type(
-               state,
-               %OpenAPI.Processor.Schema{
-                 context: [{:field, "ref", "123"}],
-                 output_format: :struct
-               },
-               %OpenAPI.Spec.Schema{}
-             ) == {"SchemaModuleNameTest", "S123"}
     end
   end
 end

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -90,20 +90,20 @@ defmodule OpenAPI.Processor.NamingTest do
   describe "rename_schema/2" do
     test "does nothing by default", %{state: state} do
       Application.put_env(:oapi_generator, @profile, naming: [rename: []])
-      assert Naming.rename_schema({"RenamedSchema", "t"}, state) == {"RenamedSchema", "t"}
+      assert Naming.rename_schema("RenamedSchema", state) == "RenamedSchema"
     end
 
     test "renames using string patterns", %{state: state} do
       Application.put_env(:oapi_generator, @profile, naming: [rename: [{"Abc", "ABC"}]])
-      assert Naming.rename_schema({"SomethingAbC", "t"}, state) == {"SomethingAbC", "t"}
-      assert Naming.rename_schema({"SomethingAbc", "t"}, state) == {"SomethingABC", "t"}
-      assert Naming.rename_schema({"SomeAbcAbcThing", "t"}, state) == {"SomeABCABCThing", "t"}
+      assert Naming.rename_schema("SomethingAbC", state) == "SomethingAbC"
+      assert Naming.rename_schema("SomethingAbc", state) == "SomethingABC"
+      assert Naming.rename_schema("SomeAbcAbcThing", state) == "SomeABCABCThing"
     end
 
     test "renames using regex patterns", %{state: state} do
       Application.put_env(:oapi_generator, @profile, naming: [rename: [{~r/^Def/, "DEF"}]])
-      assert Naming.rename_schema({"SomethingDef", "t"}, state) == {"SomethingDef", "t"}
-      assert Naming.rename_schema({"DefSomething", "t"}, state) == {"DEFSomething", "t"}
+      assert Naming.rename_schema("SomethingDef", state) == "SomethingDef"
+      assert Naming.rename_schema("DefSomething", state) == "DEFSomething"
     end
   end
 

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -154,6 +154,11 @@ defmodule OpenAPI.Processor.NamingTest do
         Naming.normalize_identifier("123", :camel)
       end
     end
+
+    test "does not raise when numerical identifier is renamed" do
+      Application.put_env(:oapi_generator, @profile, naming: [rename: [{"123", "S123"}]])
+      assert Naming.normalize_identifier("123") == "S123"
+    end
   end
 
   describe "raw_schema_module_and_type/3" do

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -154,39 +154,11 @@ defmodule OpenAPI.Processor.NamingTest do
         Naming.normalize_identifier("123", :camel)
       end
     end
-
-    test "does not raise when numerical identifier is renamed" do
-      Application.put_env(:oapi_generator, @profile, naming: [rename: [{"123", "S123"}]])
-      assert Naming.normalize_identifier("123") == "S123"
-    end
   end
 
   describe "raw_schema_module_and_type/3" do
-    test "returns schema module and type", %{state: state} do
-      state =
-        state
-        |> Map.put(:implementation, OpenAPI.Processor)
-        |> Map.put(:schemas_by_ref, %{
-          "ref" => %OpenAPI.Processor.Schema{
-            ref: "ref",
-            module_name: SchemaModuleName,
-            type_name: "t"
-          }
-        })
-        |> Map.put(:schema_specs_by_ref, %{"ref" => %OpenAPI.Spec.Schema{}})
-
-      assert Naming.raw_schema_module_and_type(
-               state,
-               %OpenAPI.Processor.Schema{
-                 context: [{:field, "ref", "test"}],
-                 output_format: :struct
-               },
-               %OpenAPI.Spec.Schema{}
-             ) == {"SchemaModuleNameTest", "t"}
-    end
-
-    test "normalizes field names based on output format", %{state: state} do
-      state =
+    setup context do
+      Map.update!(context, :state, fn state ->
         state
         |> Map.put(:implementation, OpenAPI.Processor)
         |> Map.put(:schemas_by_ref, %{
@@ -202,7 +174,21 @@ defmodule OpenAPI.Processor.NamingTest do
           }
         })
         |> Map.put(:schema_specs_by_ref, %{"ref" => %OpenAPI.Spec.Schema{}})
+      end)
+    end
 
+    test "returns schema module and type", %{state: state} do
+      assert Naming.raw_schema_module_and_type(
+               state,
+               %OpenAPI.Processor.Schema{
+                 context: [{:field, "ref", "test"}],
+                 output_format: :struct
+               },
+               %OpenAPI.Spec.Schema{}
+             ) == {"SchemaModuleNameTest", "t"}
+    end
+
+    test "normalizes field names based on output format", %{state: state} do
       assert Naming.raw_schema_module_and_type(
                state,
                %OpenAPI.Processor.Schema{
@@ -256,6 +242,20 @@ defmodule OpenAPI.Processor.NamingTest do
                },
                %OpenAPI.Spec.Schema{}
              ) == {"SchemaModuleName", "something_else_test_field"}
+    end
+
+    test "does not raise when numerical identifier is renamed", context do
+      %{state: state} = context
+      Application.put_env(:oapi_generator, @profile, naming: [rename: [{"123", "S123"}]])
+
+      assert Naming.raw_schema_module_and_type(
+               state,
+               %OpenAPI.Processor.Schema{
+                 context: [{:field, "ref", "123"}],
+                 output_format: :struct
+               },
+               %OpenAPI.Spec.Schema{}
+             ) == {"SchemaModuleNameTest", "t"}
     end
   end
 end

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -255,7 +255,7 @@ defmodule OpenAPI.Processor.NamingTest do
                  output_format: :struct
                },
                %OpenAPI.Spec.Schema{}
-             ) == {"SchemaModuleNameTest", "t"}
+             ) == {"SchemaModuleNameTest", "S123"}
     end
   end
 end

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -126,32 +126,36 @@ defmodule OpenAPI.Processor.NamingTest do
   end
 
   describe "normalize_identifier/1" do
-    test "normalizes identifiers" do
-      assert Naming.normalize_identifier("example") == "example"
-      assert Naming.normalize_identifier("example", :camel) == "Example"
+    setup :setup_for_schema_module_and_type
 
-      assert Naming.normalize_identifier("example_op") == "example_op"
-      assert Naming.normalize_identifier("example_op", :camel) == "ExampleOp"
+    test "normalizes identifiers", %{state: state} do
+      assert Naming.normalize_identifier("example", state) == "example"
+      assert Naming.normalize_identifier("example", state, :camel) == "Example"
 
-      assert Naming.normalize_identifier("exampleOp") == "example_op"
-      assert Naming.normalize_identifier("exampleOp", :camel) == "ExampleOp"
+      assert Naming.normalize_identifier("example_op", state) == "example_op"
+      assert Naming.normalize_identifier("example_op", state, :camel) == "ExampleOp"
 
-      assert Naming.normalize_identifier("mod_{NAME}/example-Op") == "mod_name_example_op"
-      assert Naming.normalize_identifier("mod_{NAME}/example-Op", :camel) == "ModNAMEExampleOp"
+      assert Naming.normalize_identifier("exampleOp", state) == "example_op"
+      assert Naming.normalize_identifier("exampleOp", state, :camel) == "ExampleOp"
+
+      assert Naming.normalize_identifier("mod_{NAME}/example-Op", state) == "mod_name_example_op"
+
+      assert Naming.normalize_identifier("mod_{NAME}/example-Op", state, :camel) ==
+               "ModNAMEExampleOp"
     end
 
-    test "preserves abbreviations" do
-      assert Naming.normalize_identifier("OpenAPISpec") == "open_api_spec"
-      assert Naming.normalize_identifier("OpenAPISpec", :camel) == "OpenAPISpec"
+    test "preserves abbreviations", %{state: state} do
+      assert Naming.normalize_identifier("OpenAPISpec", state) == "open_api_spec"
+      assert Naming.normalize_identifier("OpenAPISpec", state, :camel) == "OpenAPISpec"
     end
 
-    test "raises for numerical identifiers" do
+    test "raises for numerical identifiers", %{state: state} do
       assert_raise ArgumentError, fn ->
-        Naming.normalize_identifier("123")
+        Naming.normalize_identifier("123", state)
       end
 
       assert_raise ArgumentError, fn ->
-        Naming.normalize_identifier("123", :camel)
+        Naming.normalize_identifier("123", state, :camel)
       end
     end
   end

--- a/test/open_api/processor/naming_test.exs
+++ b/test/open_api/processor/naming_test.exs
@@ -201,7 +201,7 @@ defmodule OpenAPI.Processor.NamingTest do
                  output_format: :struct,
                  ref: "ref"
                }
-             ) == {SchemaModuleNameTest, :s123}
+             ) == {SchemaModuleNameS123, :t}
     end
   end
 


### PR DESCRIPTION
The renaming was happening after the "raise if invalid" check. This fixes that problem.

In broad strokes, I moved the renaming "higher" up in the flow.